### PR TITLE
changes check name in local drone setups to avoid conflicts

### DIFF
--- a/docker-compose.localdrone.yaml
+++ b/docker-compose.localdrone.yaml
@@ -42,7 +42,7 @@ services:
       - DRONE_WEBHOOK_ENDPOINT=http://host.docker.internal:3333/drone/webhook
       - DRONE_WEBHOOK_SECRET=bea26a2221fd8090ea38720fc445eca6
       - DRONE_USER_CREATE=username:${GH_HANDLE},admin:true
-      - DRONE_JSONNET_ENABLED=true
+      - DRONE_STATUS_NAME=continuous-integration/drone-local-${GH_HANDLE}
   runner:
     platform: 'linux/amd64'
     image: drone/drone-runner-docker:linux-amd64


### PR DESCRIPTION
as per the title, changes locally running check nams to avoif conflicth on github.

also removes support for jsonnet since we are not using it anymore