### PR TITLE
fix: handle no restarts in restarts_total

### DIFF
--- a/pkg/dronereceiver/documentation.md
+++ b/pkg/dronereceiver/documentation.md
@@ -16,6 +16,8 @@ metrics:
 
 Number of builds.
 
+Currently there's no way to differentiate between restarted builds and manually triggered builds. This means builds started manually (i.e. via Drone UI or via APis) will count towards this metric should they run against a branch for which a build has already been executed.
+
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | 1 | Sum | Int | Cumulative | false |

--- a/pkg/dronereceiver/metadata.yaml
+++ b/pkg/dronereceiver/metadata.yaml
@@ -37,6 +37,10 @@ metrics:
   builds_number:
     enabled: true
     description: Number of builds.
+    extended_documentation:
+      Currently there's no way to differentiate between restarted builds and manually triggered builds.
+      This means builds started manually (i.e. via Drone UI or via APis) will count towards this metric
+      should they run against a branch for which a build has already been executed.
     unit: 1
     sum:
       value_type: int


### PR DESCRIPTION
moves `restarts_total` to its own function and fixes a bug for which not having restarted builds would cause the query to return `null` and the metric not to be generated by coalescing `null` to `0`.

Also adds documentation about the fact that manually triggered builds can potentially count towards this metric