### PR TITLE
Auth: Add basic auth extension

### DIFF
--- a/config/builder-config.yml
+++ b/config/builder-config.yml
@@ -14,6 +14,7 @@ processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.79.0
 
 extensions:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.79.0
 
 receivers:
   - gomod: 'github.com/grafana/grafana-collector/dronereceiver v0.1.0'


### PR DESCRIPTION
1-line PR to add basic auth extension for otel.

Based on https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/e426c2d81b971dc7500c780e9ff5b1808ae7e61b/extension/basicauthextension/README.md.

Fixes part of https://github.com/grafana/grafana-ci-otel-collector/issues/32