### PR TITLE
Add repo and branch attributes to metrics

### DIFF
--- a/pkg/dronereceiver/documentation.md
+++ b/pkg/dronereceiver/documentation.md
@@ -27,6 +27,8 @@ Currently there's no way to differentiate between restarted builds and manually 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | build.status | Build status | Str: ``pending``, ``running``, ``success``, ``failure``, ``skipped``, ``error``, ``killed``, ``blocked``, ``paused``, ``waiting_on_dependencies``, ``unknown`` |
+| repo.name | Repository name | Any Str |
+| repo.branch | Branch name | Any Str |
 
 ### restarts_total
 

--- a/pkg/dronereceiver/handler.go
+++ b/pkg/dronereceiver/handler.go
@@ -98,7 +98,7 @@ func (d *droneWebhookHandler) handler(resp http.ResponseWriter, req *http.Reques
 	resourceAttrs.PutStr(conventions.AttributeServiceName, "drone")
 	resourceAttrs.PutInt("build.number", build.Number)
 	resourceAttrs.PutInt("build.id", build.ID)
-	resourceAttrs.PutStr("repo.name", repo.Name)
+	resourceAttrs.PutStr("repo.name", repo.Slug)
 	resourceAttrs.PutStr("repo.branch", repo.Branch)
 
 	buildSpan := scopeSpans.Spans().AppendEmpty()

--- a/pkg/dronereceiver/internal/metadata/generated_metrics.go
+++ b/pkg/dronereceiver/internal/metadata/generated_metrics.go
@@ -91,7 +91,7 @@ func (m *metricBuildsNumber) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricBuildsNumber) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, buildStatusAttributeValue string) {
+func (m *metricBuildsNumber) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, buildStatusAttributeValue string, repoNameAttributeValue string, repoBranchAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -100,6 +100,8 @@ func (m *metricBuildsNumber) recordDataPoint(start pcommon.Timestamp, ts pcommon
 	dp.SetTimestamp(ts)
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("build.status", buildStatusAttributeValue)
+	dp.Attributes().PutStr("repo.name", repoNameAttributeValue)
+	dp.Attributes().PutStr("repo.branch", repoBranchAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -283,8 +285,8 @@ func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 }
 
 // RecordBuildsNumberDataPoint adds a data point to builds_number metric.
-func (mb *MetricsBuilder) RecordBuildsNumberDataPoint(ts pcommon.Timestamp, val int64, buildStatusAttributeValue AttributeBuildStatus) {
-	mb.metricBuildsNumber.recordDataPoint(mb.startTime, ts, val, buildStatusAttributeValue.String())
+func (mb *MetricsBuilder) RecordBuildsNumberDataPoint(ts pcommon.Timestamp, val int64, buildStatusAttributeValue AttributeBuildStatus, repoNameAttributeValue string, repoBranchAttributeValue string) {
+	mb.metricBuildsNumber.recordDataPoint(mb.startTime, ts, val, buildStatusAttributeValue.String(), repoNameAttributeValue, repoBranchAttributeValue)
 }
 
 // RecordRestartsTotalDataPoint adds a data point to restarts_total metric.

--- a/pkg/dronereceiver/internal/metadata/generated_metrics_test.go
+++ b/pkg/dronereceiver/internal/metadata/generated_metrics_test.go
@@ -56,7 +56,7 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordBuildsNumberDataPoint(ts, 1, AttributeBuildStatus(1))
+			mb.RecordBuildsNumberDataPoint(ts, 1, AttributeBuildStatus(1), "attr-val", "attr-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -104,6 +104,12 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok := dp.Attributes().Get("build.status")
 					assert.True(t, ok)
 					assert.Equal(t, "pending", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("repo.name")
+					assert.True(t, ok)
+					assert.EqualValues(t, "attr-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("repo.branch")
+					assert.True(t, ok)
+					assert.EqualValues(t, "attr-val", attrVal.Str())
 				case "restarts_total":
 					assert.False(t, validatedMetrics["restarts_total"], "Found a duplicate in the metrics slice: restarts_total")
 					validatedMetrics["restarts_total"] = true

--- a/pkg/dronereceiver/metadata.yaml
+++ b/pkg/dronereceiver/metadata.yaml
@@ -32,6 +32,12 @@ attributes:
         unknown,
       ]
     type: string
+  repo.name:
+    description: Repository name
+    type: string
+  repo.branch:
+    description: Branch name
+    type: string
 
 metrics:
   builds_number:
@@ -46,7 +52,7 @@ metrics:
       value_type: int
       monotonic: false
       aggregation: cumulative
-    attributes: [build.status]
+    attributes: [build.status, repo.name, repo.branch]
   restarts_total:
     enabled: true
     description: Total number build restarts.


### PR DESCRIPTION
Adds repo and branch attributes to metrics, plus uses the repo's slug instead of the name in the `repo.name` property

Part of https://github.com/grafana/grafana-ci-otel-collector/issues/28 but as of now labels for each branch and repo will be created. managing cardinality explosion will be done in a future iteration