### PR TITLE
Bug: Make test step depend on build step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,8 @@ steps:
   name: build
 - commands:
   - go test ./pkg/dronereceiver
+  depends_on:
+  - build
   image: golang:1.20.4
   name: test
 trigger:
@@ -28,6 +30,8 @@ steps:
   name: build
 - commands:
   - go test ./pkg/dronereceiver
+  depends_on:
+  - build
   image: golang:1.20.4
   name: test
 trigger:
@@ -46,6 +50,8 @@ steps:
   name: build
 - commands:
   - go test ./pkg/dronereceiver
+  depends_on:
+  - build
   image: golang:1.20.4
   name: test
 - commands:

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -55,6 +55,7 @@ local verifyGenTrigger = {
       'make build',
     ]),
     step.new('test', image=goImage)
+    + step.withDependsOn(['build'])
     + step.withCommands([
       'go test ./pkg/dronereceiver',
     ]),
@@ -68,6 +69,7 @@ local verifyGenTrigger = {
       'make build',
     ]),
     step.new('test', image=goImage)
+    + step.withDependsOn(['build'])
     + step.withCommands([
       'go test ./pkg/dronereceiver',
     ]),
@@ -85,6 +87,7 @@ local verifyGenTrigger = {
       'make build',
     ]),
     step.new('test', image=goImage)
+    + step.withDependsOn(['build'])
     + step.withCommands([
       'go test ./pkg/dronereceiver',
     ]),


### PR DESCRIPTION
Looks like a weird PR, since test depends on building the collector, but because we need to test what's in the collector dir which gets generated when `make build` runs, we need to add dependencies on them