### PR TITLE
CD: Fix deployment_tools PR title

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,7 @@ steps:
         "pull_request_branch_prefix": "grafana-ci-otel-collector/",
         "pull_request_enabled": true,
         "pull_request_team_reviewers": [],
-        "pull_request_title": "[CI/CD] Update grafana-ci-otel-collector",
+        "pull_request_title": "Update grafana-ci-otel-collector",
         "repo_name": "deployment_tools",
         "update_jsonnet_attribute_configs": [
           {

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -135,7 +135,7 @@ step.new('build-docker-image', image=dockerDINDImage)
           "pull_request_branch_prefix": "grafana-ci-otel-collector/",
           "pull_request_enabled": true,
           "pull_request_team_reviewers": [],
-          "pull_request_title": "[CI/CD] Update grafana-ci-otel-collector",
+          "pull_request_title": "Update grafana-ci-otel-collector",
           "repo_name": "deployment_tools",
           "update_jsonnet_attribute_configs": [
             {


### PR DESCRIPTION
Fixes deployment_tools PR title. Currently the PR title starts with `[CI/CD] [CI/CD] ...`. This PR removes the duplicated entry.