### PR TITLE
Chore: cleanup status attribute

### DIFF
--- a/pkg/dronereceiver/documentation.md
+++ b/pkg/dronereceiver/documentation.md
@@ -26,7 +26,7 @@ Currently there's no way to differentiate between restarted builds and manually 
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| build.status | Build status | Str: ``pending``, ``running``, ``success``, ``failure``, ``skipped``, ``error``, ``killed``, ``blocked``, ``paused``, ``waiting_on_dependencies``, ``unknown`` |
+| build.status | Build status | Str: ``skipped``, ``blocked``, ``declined``, ``waiting_on_dependencies``, ``pending``, ``running``, ``success``, ``failure``, ``killed``, ``error`` |
 | repo.name | Repository name | Any Str |
 | repo.branch | Branch name | Any Str |
 

--- a/pkg/dronereceiver/internal/metadata/generated_metrics.go
+++ b/pkg/dronereceiver/internal/metadata/generated_metrics.go
@@ -17,22 +17,29 @@ type AttributeBuildStatus int
 
 const (
 	_ AttributeBuildStatus = iota
+	AttributeBuildStatusSkipped
+	AttributeBuildStatusBlocked
+	AttributeBuildStatusDeclined
+	AttributeBuildStatusWaitingOnDependencies
 	AttributeBuildStatusPending
 	AttributeBuildStatusRunning
 	AttributeBuildStatusSuccess
 	AttributeBuildStatusFailure
-	AttributeBuildStatusSkipped
-	AttributeBuildStatusError
 	AttributeBuildStatusKilled
-	AttributeBuildStatusBlocked
-	AttributeBuildStatusPaused
-	AttributeBuildStatusWaitingOnDependencies
-	AttributeBuildStatusUnknown
+	AttributeBuildStatusError
 )
 
 // String returns the string representation of the AttributeBuildStatus.
 func (av AttributeBuildStatus) String() string {
 	switch av {
+	case AttributeBuildStatusSkipped:
+		return "skipped"
+	case AttributeBuildStatusBlocked:
+		return "blocked"
+	case AttributeBuildStatusDeclined:
+		return "declined"
+	case AttributeBuildStatusWaitingOnDependencies:
+		return "waiting_on_dependencies"
 	case AttributeBuildStatusPending:
 		return "pending"
 	case AttributeBuildStatusRunning:
@@ -41,37 +48,26 @@ func (av AttributeBuildStatus) String() string {
 		return "success"
 	case AttributeBuildStatusFailure:
 		return "failure"
-	case AttributeBuildStatusSkipped:
-		return "skipped"
-	case AttributeBuildStatusError:
-		return "error"
 	case AttributeBuildStatusKilled:
 		return "killed"
-	case AttributeBuildStatusBlocked:
-		return "blocked"
-	case AttributeBuildStatusPaused:
-		return "paused"
-	case AttributeBuildStatusWaitingOnDependencies:
-		return "waiting_on_dependencies"
-	case AttributeBuildStatusUnknown:
-		return "unknown"
+	case AttributeBuildStatusError:
+		return "error"
 	}
 	return ""
 }
 
 // MapAttributeBuildStatus is a helper map of string to AttributeBuildStatus attribute value.
 var MapAttributeBuildStatus = map[string]AttributeBuildStatus{
+	"skipped":                 AttributeBuildStatusSkipped,
+	"blocked":                 AttributeBuildStatusBlocked,
+	"declined":                AttributeBuildStatusDeclined,
+	"waiting_on_dependencies": AttributeBuildStatusWaitingOnDependencies,
 	"pending":                 AttributeBuildStatusPending,
 	"running":                 AttributeBuildStatusRunning,
 	"success":                 AttributeBuildStatusSuccess,
 	"failure":                 AttributeBuildStatusFailure,
-	"skipped":                 AttributeBuildStatusSkipped,
-	"error":                   AttributeBuildStatusError,
 	"killed":                  AttributeBuildStatusKilled,
-	"blocked":                 AttributeBuildStatusBlocked,
-	"paused":                  AttributeBuildStatusPaused,
-	"waiting_on_dependencies": AttributeBuildStatusWaitingOnDependencies,
-	"unknown":                 AttributeBuildStatusUnknown,
+	"error":                   AttributeBuildStatusError,
 }
 
 type metricBuildsNumber struct {

--- a/pkg/dronereceiver/internal/metadata/generated_metrics_test.go
+++ b/pkg/dronereceiver/internal/metadata/generated_metrics_test.go
@@ -56,7 +56,7 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordBuildsNumberDataPoint(ts, 1, AttributeBuildStatusPending, "repo.name-val", "repo.branch-val")
+			mb.RecordBuildsNumberDataPoint(ts, 1, AttributeBuildStatusSkipped, "repo.name-val", "repo.branch-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -101,7 +101,7 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, int64(1), dp.IntValue())
 					attrVal, ok := dp.Attributes().Get("build.status")
 					assert.True(t, ok)
-					assert.EqualValues(t, "pending", attrVal.Str())
+					assert.EqualValues(t, "skipped", attrVal.Str())
 					attrVal, ok = dp.Attributes().Get("repo.name")
 					assert.True(t, ok)
 					assert.EqualValues(t, "repo.name-val", attrVal.Str())

--- a/pkg/dronereceiver/metadata.yaml
+++ b/pkg/dronereceiver/metadata.yaml
@@ -16,20 +16,18 @@ resource_attributes:
 attributes:
   build.status:
     description: Build status
-    # TODO: double check if the following list is correct
     enum:
       [
+        skipped,
+        blocked,
+        declined,
+        waiting_on_dependencies,
         pending,
         running,
         success,
         failure,
-        skipped,
-        error,
         killed,
-        blocked,
-        paused,
-        waiting_on_dependencies,
-        unknown,
+        error,
       ]
     type: string
   repo.name:


### PR DESCRIPTION
cleanups the status attribute by including only the possible values as defined in https://github.com/drone/drone-go/blob/master/drone/const.go#L27