### PR TITLE
Add repo info metrics

### DIFF
--- a/config/tempo.yaml
+++ b/config/tempo.yaml
@@ -12,7 +12,7 @@ ingester:
 
 compactor:
   compaction:
-    block_retention: 6h # overall Tempo trace retention. set for demo purposes
+    block_retention: 168h # overall Tempo trace retention. set for demo purposes
 
 metrics_generator:
   registry:

--- a/pkg/dronereceiver/documentation.md
+++ b/pkg/dronereceiver/documentation.md
@@ -30,6 +30,22 @@ Currently there's no way to differentiate between restarted builds and manually 
 | repo.name | Repository name | Any Str |
 | repo.branch | Branch name | Any Str |
 
+### repo_info
+
+Repo status.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| 1 | Sum | Int | Cumulative | false |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| build.status | Build status | Str: ``skipped``, ``blocked``, ``declined``, ``waiting_on_dependencies``, ``pending``, ``running``, ``success``, ``failure``, ``killed``, ``error`` |
+| repo.name | Repository name | Any Str |
+| repo.branch | Branch name | Any Str |
+
 ### restarts_total
 
 Total number build restarts.

--- a/pkg/dronereceiver/internal/metadata/generated_config.go
+++ b/pkg/dronereceiver/internal/metadata/generated_config.go
@@ -26,12 +26,16 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 // MetricsConfig provides config for dronereceiver metrics.
 type MetricsConfig struct {
 	BuildsNumber  MetricConfig `mapstructure:"builds_number"`
+	RepoInfo      MetricConfig `mapstructure:"repo_info"`
 	RestartsTotal MetricConfig `mapstructure:"restarts_total"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		BuildsNumber: MetricConfig{
+			Enabled: true,
+		},
+		RepoInfo: MetricConfig{
 			Enabled: true,
 		},
 		RestartsTotal: MetricConfig{

--- a/pkg/dronereceiver/internal/metadata/generated_config_test.go
+++ b/pkg/dronereceiver/internal/metadata/generated_config_test.go
@@ -27,6 +27,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
 					BuildsNumber:  MetricConfig{Enabled: true},
+					RepoInfo:      MetricConfig{Enabled: true},
 					RestartsTotal: MetricConfig{Enabled: true},
 				},
 			},
@@ -36,6 +37,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
 					BuildsNumber:  MetricConfig{Enabled: false},
+					RepoInfo:      MetricConfig{Enabled: false},
 					RestartsTotal: MetricConfig{Enabled: false},
 				},
 			},

--- a/pkg/dronereceiver/internal/metadata/testdata/config.yaml
+++ b/pkg/dronereceiver/internal/metadata/testdata/config.yaml
@@ -3,11 +3,15 @@ all_set:
   metrics:
     builds_number:
       enabled: true
+    repo_info:
+      enabled: true
     restarts_total:
       enabled: true
 none_set:
   metrics:
     builds_number:
+      enabled: false
+    repo_info:
       enabled: false
     restarts_total:
       enabled: false

--- a/pkg/dronereceiver/metadata.yaml
+++ b/pkg/dronereceiver/metadata.yaml
@@ -51,6 +51,15 @@ metrics:
       monotonic: false
       aggregation: cumulative
     attributes: [build.status, repo.name, repo.branch]
+  repo_info:
+    enabled: true
+    description: Repo status.
+    unit: 1
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation: cumulative
+    attributes: [build.status, repo.name, repo.branch]
   restarts_total:
     enabled: true
     description: Total number build restarts.

--- a/pkg/dronereceiver/scraper.go
+++ b/pkg/dronereceiver/scraper.go
@@ -70,6 +70,7 @@ func (r *droneScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 	r.scrapeBuilds(ctx, now, errs)
 	r.scrapeRestartedBuilds(ctx, now, errs)
+	r.scrapeInfo(ctx, now, errs)
 
 	return r.mb.Emit(), errs.Combine()
 }
@@ -157,4 +158,48 @@ func (r *droneScraper) scrapeRestartedBuilds(ctx context.Context, now pcommon.Ti
 		errs.Add(err)
 	}
 	r.mb.RecordRestartsTotalDataPoint(now, count)
+}
+
+func (r *droneScraper) scrapeInfo(ctx context.Context, now pcommon.Timestamp, errs *scrapererror.ScrapeErrors) {
+	rows, err := r.db.Query(ctx, `
+		SELECT build_status, r.repo_slug, build_source FROM builds
+		LEFT JOIN
+			repos r
+		ON 
+			build_repo_id = r.repo_id 
+		WHERE build_id IN (
+		Select MAX(build_id) 
+			from 
+				builds 
+			JOIN 
+				repos r 
+			ON 
+				build_repo_id = r.repo_id
+			WHERE 
+				build_status not in ('running','waiting_on_dependencies','pending') 
+				AND (
+					(repo_slug = 'grafana/gracie' and build_source in ('main')) OR
+					(repo_slug = 'grafana/grafana-ci-otel-collector' and build_source in ('main')) OR
+					(repo_slug = 'grafana/grafana' and build_source in ('main', 'v10.0.x', 'v10.1.x'))
+				)
+			Group by build_repo_id, build_source
+		)
+	`)
+
+	if err != nil {
+		errs.Add(err)
+	}
+
+	for rows.Next() {
+		var status string
+		var slug string
+		var source string
+		err := rows.Scan(&status, &slug, &source)
+		if err != nil {
+			errs.Add(err)
+			continue
+		}
+
+		r.mb.RecordRepoInfoDataPoint(now, 1, metadata.MapAttributeBuildStatus[status], slug, source)
+	}
 }


### PR DESCRIPTION
This is a bit funny. basically we create a gauge for each repo/tracked branch so that we can use their labels to get repos info. this is siilar to what argoCD does (https://argo-cd.readthedocs.io/en/stable/operator-manual/metrics/) and allows us to generate a berry nice state timeline for each repo/tracjed branch: 
![Screenshot 2023-08-09 at 14 23 46](https://github.com/grafana/grafana-ci-otel-collector/assets/1170767/75f214cc-e452-495d-84d0-6a40e0ded783)
