### PR TITLE
Gracie CD: Make `NETWORK_HOST` arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.20-alpine3.17 as go-builder
 WORKDIR /collector
 
-ENV NETWORK_HOST=host.docker.internal
+ARG network_host
+ENV NETWORK_HOST $network_host
 
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,13 @@ docker-build:
 	@echo "building docker container grafana-ci-otel-collector"
 	docker build -t grafana-ci-otel-collector .
 
+docker-build-local:
+	@echo "building docker container grafana-ci-otel-collector"
+	docker build -t grafana-ci-otel-collector --build-arg network_host=host.docker.internal .
+
 docker-run:
 	@echo "running docker container"
 	docker run -it -v $$PWD:/tmp -e NETWORK_HOST=host.docker.internal -p 3333:3333 \
  		grafana-ci-otel-collector:latest --config /tmp/config.yaml
 
-docker: docker-build docker-run
+docker: docker-build-local docker-run

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ NETWORK_HOST=localhost && make metadata && make build && make run
 Build the Docker image:
 
 ```bash
-make docker-build
+make docker-build-local
 ```
 
 Run the Docker image:


### PR DESCRIPTION
`NETWORK_HOST` and `DRONE_ENDPOINT` override each other, since `NETWORK_HOST` is set while the docker image is being built, and thus is available as an env variable in the deployment.
We need `NETWORK_HOST` to be available for local dev, but we need `DRONE_ENDPOINT` to take its place in case it's present in production.

This PR, is responsible for passing `NETWORK_HOST` as an argument while building the image locally. If it's not a local run, then the `NETWORK_HOST` var shouldn't be set.

Part of: https://github.com/grafana/grafana-ci-otel-collector/issues/40