### PR TITLE
Chore: Add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+// Make the gracie team codeowners for the whole repo's codebase
+* @grafana/gracie


### PR DESCRIPTION
Adds CODEOWNERS file, to automatically assign gracie team members as reviewers.