### PR TITLE
Spans: Add `spanmetricscollector`

### DIFF
--- a/config/builder-config.yml
+++ b/config/builder-config.yml
@@ -11,6 +11,9 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.82.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.82.0
 
+connectors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.82.0
+
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.82.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.82.0


### PR DESCRIPTION
Adds `spanmetricscollector`, according to https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md