### PR TITLE
CI: Add build docker image step to pr pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,10 @@ trigger:
   event:
   - pull_request
 type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
 ---
 image_pull_secrets:
 - dockerconfigjson

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -49,6 +49,9 @@ local verifyGenTrigger = {
   pl.new('pr')
   + pl.withImagePullSecrets(['dockerconfigjson'])
   + pl.withTrigger(prTrigger)
+  + pl.withVolumes([
+    dockerVolume,
+  ])
   + pl.withSteps([
     step.new('build', image=goImage)
     + step.withCommands([


### PR DESCRIPTION
Yesterday we caught a bug regarding the docker image build after we merged to main, because we didn't run the `build-docker-image` step for PRs.
This PR adds the step in the PR pipeline