### PR TITLE
CD: Split `update-deployment-tools` step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -93,7 +93,34 @@ steps:
 - depends_on:
   - publish-to-gcr
   image: us.gcr.io/kubernetes-dev/drone/plugins/updater
-  name: update-deployment-tools
+  name: update-deployment-tools-dev
+  settings:
+    config_json: |
+      {
+        "destination_branch": "master",
+        "pull_request_branch_prefix": "grafana-ci-otel-collector/",
+        "pull_request_enabled": false,
+        "pull_request_team_reviewers": [],
+        "pull_request_title": "Update grafana-ci-otel-collector",
+        "repo_name": "deployment_tools",
+        "update_jsonnet_attribute_configs": [
+          {
+            "file_path": "ksonnet/environments/grafana-ci-otel-collector/images.libsonnet",
+            "jsonnet_key": "dev",
+            "jsonnet_value": "us.gcr.io/kubernetes-dev/grafana-ci-otel-collector:${DRONE_COMMIT}"
+          }
+        ]
+      }
+    github_app_id:
+      from_secret: gh_app_id
+    github_app_installation_id:
+      from_secret: gh_app_installation_id
+    github_app_private_key:
+      from_secret: gh_app_private_key
+- depends_on:
+  - publish-to-gcr
+  image: us.gcr.io/kubernetes-dev/drone/plugins/updater
+  name: update-deployment-tools-ops
   settings:
     config_json: |
       {
@@ -106,7 +133,7 @@ steps:
         "update_jsonnet_attribute_configs": [
           {
             "file_path": "ksonnet/environments/grafana-ci-otel-collector/images.libsonnet",
-            "jsonnet_key": "collector",
+            "jsonnet_key": "ops",
             "jsonnet_value": "us.gcr.io/kubernetes-dev/grafana-ci-otel-collector:${DRONE_COMMIT}"
           }
         ]


### PR DESCRIPTION
Splits `update-deployment-tools` step to dev and ops. This will eventually mean that every time we merge a PR to main, the dev instance will be automatically updated, but for the ops instance, we'll still need to approve and merge a PR. 

Related to: https://github.com/grafana/deployment_tools/pull/88729/files

Eventually, the prod deployment should happen upon tagging.