### PR TITLE
Logs: add repo attribute to logs

### DIFF
--- a/pkg/dronereceiver/handler.go
+++ b/pkg/dronereceiver/handler.go
@@ -214,6 +214,8 @@ func (d *droneWebhookHandler) handler(resp http.ResponseWriter, req *http.Reques
 					record.SetTimestamp(pcommon.Timestamp((step.Started+line.Timestamp)*1000000000 + delta))
 					record.Attributes().PutStr(CI_STAGE, stage.Name)
 					record.Attributes().PutStr(CI_STEP, step.Name)
+
+					record.Attributes().PutStr("repo.name", repo.Slug)
 					record.Body().SetStr(line.Message)
 				}
 			}


### PR DESCRIPTION
Adds the `repo.name` attribute to logs.

i'm not adding the `repo.branch` attribute at this stage because i think we should revisit also how that attribute is added for traces. currently we add `repo.branch` also for PRs, when its value is the target branch and not the source branch. this makes it impossible to distinguish between builds happened after a merge and builds happened on PRs.