### PR TITLE
`cicd-o11y`: Add healthcheckextension

### DIFF
--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -25,6 +25,7 @@ processors:
 extensions:
   # Used for basic auth in production deployments for grafana cloud.
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.99.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.99.0
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.99.0


### PR DESCRIPTION
Adds healthcheckextension to add `/health` endpoint in the collector config