### PR TITLE
update gha receiver

### DIFF
--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -36,7 +36,7 @@ replaces:
   - github.com/grafana/grafana-ci-otel-collector/receiver/dronereceiver => ../receiver/dronereceiver
   - github.com/grafana/grafana-ci-otel-collector/internal/semconv => ../internal/semconv
   - github.com/grafana/grafana-ci-otel-collector/internal/traceutils => ../internal/traceutils
-  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubactionsreceiver => github.com/grafana/opentelemetry-collector-contrib/receiver/githubactionsreceiver e46f054
+  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubactionsreceiver => github.com/grafana/opentelemetry-collector-contrib/receiver/githubactionsreceiver 94f6703
 
 excludes:
   - github.com/knadh/koanf v1.5.0


### PR DESCRIPTION
Updates the GHA receiver to 94f67035aacc07804e3422b8eb6713f6abaec0f9 (https://github.com/grafana/opentelemetry-collector-contrib/commit/94f67035aacc07804e3422b8eb6713f6abaec0f9)