### PR TITLE
Metrics: Add `DefaultMetricsBuilderConfig` in createDefaultConfig() func

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,9 @@ jobs:
         uses: grafana/shared-workflows/actions/push-to-gar-docker@main
         with:
           # Only push to GAR on main branch pushes
-          push: ${{ github.event_name == 'push' && github.ref_name == 'main' && 'true' || 'false' }}
+          push: true
           tags: |-
             ${{ github.sha }}
-            "latest"
           context: "."
           image_name: "grafana-ci-otel-collector"
           environment: "dev"

--- a/receiver/githubactionsreceiver/config_test.go
+++ b/receiver/githubactionsreceiver/config_test.go
@@ -154,6 +154,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	expect := &Config{
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 		ServerConfig: confighttp.ServerConfig{
 			Endpoint: "localhost:8080",
 		},

--- a/receiver/githubactionsreceiver/factory.go
+++ b/receiver/githubactionsreceiver/factory.go
@@ -33,6 +33,7 @@ func NewFactory() receiver.Factory {
 // createDefaultConfig creates the default configuration for GitHub Actions receiver.
 func createDefaultConfig() component.Config {
 	return &Config{
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 		ServerConfig: confighttp.ServerConfig{
 			Endpoint: defaultBindEndpoint,
 		},


### PR DESCRIPTION
Followup to: https://github.com/grafana/grafana-ci-otel-collector/pull/130

As far as I understand the new metrics should be enabled by default. Also, there's no sign of the new metrics configuration being picked up anywhere. This PR does that.