### PR TITLE
fix: make metrics cumulative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-debug: install-tools
 
 .PHONY: run
 run: build
-	$(CUSTOM_COL_DIR)/grafana-ci-otelcol --config config/config.yaml
+	$(CUSTOM_COL_DIR)/grafana-ci-otelcol --config config.yaml
 
 .PHONY: for-all
 for-all:

--- a/receiver/githubactionsreceiver/config_test.go
+++ b/receiver/githubactionsreceiver/config_test.go
@@ -154,6 +154,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	expect := &Config{
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 		ServerConfig: confighttp.ServerConfig{
 			Endpoint: "localhost:8080",
 		},

--- a/receiver/githubactionsreceiver/documentation.md
+++ b/receiver/githubactionsreceiver/documentation.md
@@ -18,7 +18,7 @@ Number of jobs.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Delta | true |
+| 1 | Sum | Int | Cumulative | true |
 
 #### Attributes
 

--- a/receiver/githubactionsreceiver/factory.go
+++ b/receiver/githubactionsreceiver/factory.go
@@ -33,6 +33,7 @@ func NewFactory() receiver.Factory {
 // createDefaultConfig creates the default configuration for GitHub Actions receiver.
 func createDefaultConfig() component.Config {
 	return &Config{
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 		ServerConfig: confighttp.ServerConfig{
 			Endpoint: defaultBindEndpoint,
 		},

--- a/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
@@ -58,7 +58,7 @@ func (m *metricWorkflowJobsTotal) init() {
 	m.data.SetUnit("1")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 

--- a/receiver/githubactionsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_metrics_test.go
@@ -93,7 +93,7 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, "Number of jobs.", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					assert.Equal(t, true, ms.At(i).Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityDelta, ms.At(i).Sum().AggregationTemporality())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
 					dp := ms.At(i).Sum().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())

--- a/receiver/githubactionsreceiver/metadata.yaml
+++ b/receiver/githubactionsreceiver/metadata.yaml
@@ -38,7 +38,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation_temporality: delta
+      aggregation_temporality: cumulative
     attributes:
       [
         vcs.repository.name,


### PR DESCRIPTION
in https://github.com/grafana/grafana-ci-otel-collector/pull/130, queue metrics were wrongly defined as delta while they were in fact cumulative (besides from preventing `prometheusremotewrite` to process them, see https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md)

> ⚠️ Non-cumulative monotonic, histogram, and summary OTLP metrics are dropped by this exporter.

It also includes the fixes in https://github.com/grafana/grafana-ci-otel-collector/pull/131/ to create a default metrics builder config, without this change metrics needed to be enabled manually while the documentation stated otherwise.