### PR TITLE
chore: add event to metrics tests

### DIFF
--- a/receiver/githubactionsreceiver/metric_event_handling.go
+++ b/receiver/githubactionsreceiver/metric_event_handling.go
@@ -19,19 +19,21 @@ type metricsHandler struct {
 	settings component.TelemetrySettings
 	mb       *metadata.MetricsBuilder
 	cfg      *Config
+	logger   *zap.Logger
 }
 
 var mCache = sync.Map{}
 
-func newMetricsHandler(settings receiver.Settings, cfg *Config) *metricsHandler {
+func newMetricsHandler(settings receiver.Settings, cfg *Config, logger *zap.Logger) *metricsHandler {
 	return &metricsHandler{
 		cfg:      cfg,
 		settings: settings.TelemetrySettings,
 		mb:       metadata.NewMetricsBuilder(cfg.MetricsBuilderConfig, settings),
+		logger:   logger,
 	}
 }
 
-func (m *metricsHandler) eventToMetrics(event *github.WorkflowJobEvent, config *Config, logger *zap.Logger) pmetric.Metrics {
+func (m *metricsHandler) eventToMetrics(event *github.WorkflowJobEvent) pmetric.Metrics {
 	repo := event.GetRepo().GetFullName()
 
 	labels := ""

--- a/receiver/githubactionsreceiver/receiver.go
+++ b/receiver/githubactionsreceiver/receiver.go
@@ -88,7 +88,7 @@ func newReceiver(
 		logger:         params.Logger,
 		obsrecv:        obsrecv,
 		ghClient:       ghClient,
-		metricsHandler: *newMetricsHandler(params, config),
+		metricsHandler: *newMetricsHandler(params, config, params.Logger.Named("metricsHandler")),
 	}
 
 	return gar, nil
@@ -226,7 +226,7 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	switch e := event.(type) {
 	case *github.WorkflowJobEvent:
 		if gar.metricsConsumer != nil && e.GetWorkflowJob().GetConclusion() != "skipped" {
-			err := gar.metricsConsumer.ConsumeMetrics(ctx, gar.metricsHandler.eventToMetrics(e, gar.config, gar.logger.Named("eventToMetrics")))
+			err := gar.metricsConsumer.ConsumeMetrics(ctx, gar.metricsHandler.eventToMetrics(e))
 
 			if err != nil {
 				gar.logger.Error("Failed to consume metrics", zap.Error(err))

--- a/receiver/githubactionsreceiver/receiver_test.go
+++ b/receiver/githubactionsreceiver/receiver_test.go
@@ -145,8 +145,8 @@ func TestEventToMetrics(t *testing.T) {
 
 			metrics := mh.eventToMetrics(event.(*github.WorkflowJobEvent))
 
-			require.Equal(t, test.expectedMetrics, metrics.MetricCount(), fmt.Sprintf("%s: unexpected number of metrics", test.desc))
-			require.Equal(t, len(metadata.MapAttributeCiGithubWorkflowJobStatus), metrics.DataPointCount(), fmt.Sprintf("%s: unexpected number of datapoints", test.desc))
+			require.Equalf(t, test.expectedMetrics, metrics.MetricCount(), "%s: unexpected number of metrics", test.desc)
+			require.Equalf(t, len(metadata.MapAttributeCiGithubWorkflowJobStatus), metrics.DataPointCount(), "%s: unexpected number of datapoints", test.desc)
 		})
 	}
 }

--- a/receiver/githubactionsreceiver/receiver_test.go
+++ b/receiver/githubactionsreceiver/receiver_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v62/github"
+	"github.com/grafana/grafana-ci-otel-collector/receiver/githubactionsreceiver/internal/metadata"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer"
@@ -104,6 +105,48 @@ func TestEventToTracesTraces(t *testing.T) {
 			}
 
 			require.Equal(t, test.expectedSpans, traces.SpanCount(), fmt.Sprintf("%s: unexpected number of spans", test.desc))
+		})
+	}
+}
+
+func TestEventToMetrics(t *testing.T) {
+	tests := []struct {
+		desc            string
+		payloadFilePath string
+		eventType       string
+		expectedMetrics int
+	}{
+		{
+			desc:            "WorkflowJobEvent processing",
+			payloadFilePath: "./testdata/queued/1_workflow_job_queued.json",
+			eventType:       "workflow_job",
+			expectedMetrics: 1,
+		},
+	}
+
+	logger := zaptest.NewLogger(t)
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			payload, err := os.ReadFile(test.payloadFilePath)
+			require.NoError(t, err)
+
+			event, err := github.ParseWebHook(test.eventType, payload)
+			require.NoError(t, err)
+
+			mh := newMetricsHandler(receivertest.NewNopSettings(), &Config{
+				MetricsBuilderConfig: metadata.MetricsBuilderConfig{
+					Metrics: metadata.MetricsConfig{
+						WorkflowJobsTotal: metadata.MetricConfig{
+							Enabled: true,
+						},
+					},
+				},
+			}, logger.Named("metricsHandler"))
+
+			metrics := mh.eventToMetrics(event.(*github.WorkflowJobEvent))
+
+			require.Equal(t, test.expectedMetrics, metrics.MetricCount(), fmt.Sprintf("%s: unexpected number of metrics", test.desc))
+			require.Equal(t, len(metadata.MapAttributeCiGithubWorkflowJobStatus), metrics.DataPointCount(), fmt.Sprintf("%s: unexpected number of datapoints", test.desc))
 		})
 	}
 }


### PR DESCRIPTION
 Follow up to https://github.com/grafana/grafana-ci-otel-collector/pull/144

Add tests for the metrics event handling. the test should make sure that for a given status, datapoints are registered also for all other statuses.