### PR TITLE
ci: change updater images paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,8 +196,8 @@ jobs:
             "repo_owner": "grafana",
             "update_jsonnet_attribute_configs": [
               {
-                "file_path": "ksonnet/environments/cicd-o11y/images.libsonnet",
-                "jsonnet_key": "dev",
+                "file_path": "ksonnet/environments/cicd-o11y/images/dev.libsonnet",
+                "jsonnet_key": "image",
                 "jsonnet_value": "us-docker.pkg.dev/grafanalabs-dev/docker-grafana-ci-otel-collector-dev/grafana-ci-otel-collector:${{ github.sha }}"
               }
             ]
@@ -231,8 +231,8 @@ jobs:
             "repo_owner": "grafana",
             "update_jsonnet_attribute_configs": [
               {
-                "file_path": "ksonnet/environments/cicd-o11y/images.libsonnet",
-                "jsonnet_key": "ops",
+                "file_path": "ksonnet/environments/cicd-o11y/images/ops.libsonnet",
+                "jsonnet_key": "image",
                 "jsonnet_value": "us-docker.pkg.dev/grafanalabs-dev/docker-grafana-ci-otel-collector-dev/grafana-ci-otel-collector:${{ github.sha }}"
               }
             ]


### PR DESCRIPTION
Follow up to https://github.com/grafana/deployment_tools/pull/177955

The way the image updater is set up causes merge conflicts on the images file because 2 PRs are created from the same base and touch the same file, one for `ops` and one for `dev` (automerged).

By moving those to separate files we should be able to avoid those merge conflicts.