### PR TITLE
[WIP] Add aborted job status

### DIFF
--- a/receiver/githubactionsreceiver/documentation.md
+++ b/receiver/githubactionsreceiver/documentation.md
@@ -26,5 +26,5 @@ Number of jobs.
 | ---- | ----------- | ------ |
 | vcs.repository.name | Repository name | Any Str |
 | ci.github.workflow.job.labels | Job labels. | Any Str |
-| ci.github.workflow.job.status | Job status | Str: ``completed``, ``in_progress``, ``queued``, ``waiting`` |
+| ci.github.workflow.job.status | Job status | Str: ``completed``, ``in_progress``, ``queued``, ``waiting``, ``aborted`` |
 | ci.github.workflow.job.conclusion | Job Conclusion | Str: ``success``, ``failure``, ``cancelled``, ``neutral``, ``null`` |

--- a/receiver/githubactionsreceiver/generated_component_test.go
+++ b/receiver/githubactionsreceiver/generated_component_test.go
@@ -28,26 +28,26 @@ func TestComponentLifecycle(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		createFn func(ctx context.Context, set receiver.Settings, cfg component.Config) (component.Component, error)
+		createFn func(ctx context.Context, set receiver.CreateSettings, cfg component.Config) (component.Component, error)
 	}{
 
 		{
 			name: "logs",
-			createFn: func(ctx context.Context, set receiver.Settings, cfg component.Config) (component.Component, error) {
+			createFn: func(ctx context.Context, set receiver.CreateSettings, cfg component.Config) (component.Component, error) {
 				return factory.CreateLogsReceiver(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
 
 		{
 			name: "metrics",
-			createFn: func(ctx context.Context, set receiver.Settings, cfg component.Config) (component.Component, error) {
+			createFn: func(ctx context.Context, set receiver.CreateSettings, cfg component.Config) (component.Component, error) {
 				return factory.CreateMetricsReceiver(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
 
 		{
 			name: "traces",
-			createFn: func(ctx context.Context, set receiver.Settings, cfg component.Config) (component.Component, error) {
+			createFn: func(ctx context.Context, set receiver.CreateSettings, cfg component.Config) (component.Component, error) {
 				return factory.CreateTracesReceiver(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
@@ -58,23 +58,23 @@ func TestComponentLifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	sub, err := cm.Sub("tests::config")
 	require.NoError(t, err)
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	for _, test := range tests {
 		t.Run(test.name+"-shutdown", func(t *testing.T) {
-			c, err := test.createFn(context.Background(), receivertest.NewNopSettings(), cfg)
+			c, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})
 		t.Run(test.name+"-lifecycle", func(t *testing.T) {
-			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopSettings(), cfg)
+			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
 			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))
-			secondRcvr, err := test.createFn(context.Background(), receivertest.NewNopSettings(), cfg)
+			secondRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
 			require.NoError(t, secondRcvr.Start(context.Background(), host))
 			require.NoError(t, secondRcvr.Shutdown(context.Background()))

--- a/receiver/githubactionsreceiver/generated_package_test.go
+++ b/receiver/githubactionsreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package githubactionsreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/githubactionsreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
 
@@ -54,6 +55,6 @@ func loadMetricsBuilderConfig(t *testing.T, name string) MetricsBuilderConfig {
 	sub, err := cm.Sub(name)
 	require.NoError(t, err)
 	cfg := DefaultMetricsBuilderConfig()
-	require.NoError(t, sub.Unmarshal(&cfg))
+	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
 	return cfg
 }

--- a/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
@@ -58,6 +58,7 @@ const (
 	AttributeCiGithubWorkflowJobStatusInProgress
 	AttributeCiGithubWorkflowJobStatusQueued
 	AttributeCiGithubWorkflowJobStatusWaiting
+	AttributeCiGithubWorkflowJobStatusAborted
 )
 
 // String returns the string representation of the AttributeCiGithubWorkflowJobStatus.
@@ -71,6 +72,8 @@ func (av AttributeCiGithubWorkflowJobStatus) String() string {
 		return "queued"
 	case AttributeCiGithubWorkflowJobStatusWaiting:
 		return "waiting"
+	case AttributeCiGithubWorkflowJobStatusAborted:
+		return "aborted"
 	}
 	return ""
 }
@@ -81,6 +84,7 @@ var MapAttributeCiGithubWorkflowJobStatus = map[string]AttributeCiGithubWorkflow
 	"in_progress": AttributeCiGithubWorkflowJobStatusInProgress,
 	"queued":      AttributeCiGithubWorkflowJobStatusQueued,
 	"waiting":     AttributeCiGithubWorkflowJobStatusWaiting,
+	"aborted":     AttributeCiGithubWorkflowJobStatusAborted,
 }
 
 type metricWorkflowJobsTotal struct {

--- a/receiver/githubactionsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_metrics_test.go
@@ -48,7 +48,7 @@ func TestMetricsBuilder(t *testing.T) {
 			start := pcommon.Timestamp(1_000_000_000)
 			ts := pcommon.Timestamp(1_000_001_000)
 			observedZapCore, observedLogs := observer.New(zap.WarnLevel)
-			settings := receivertest.NewNopSettings()
+			settings := receivertest.NewNopCreateSettings()
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, test.name), settings, WithStartTime(start))
 

--- a/receiver/githubactionsreceiver/internal/metadata/generated_status.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_status.go
@@ -4,11 +4,12 @@ package metadata
 
 import (
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var (
-	Type      = component.MustNewType("githubactions")
-	ScopeName = "github.com/grafana/grafana-ci-otel-collector/receiver/githubactionsreceiver"
+	Type = component.MustNewType("githubactions")
 )
 
 const (
@@ -16,3 +17,11 @@ const (
 	LogsStability    = component.StabilityLevelAlpha
 	MetricsStability = component.StabilityLevelAlpha
 )
+
+func Meter(settings component.TelemetrySettings) metric.Meter {
+	return settings.MeterProvider.Meter("github.com/grafana/grafana-ci-otel-collector/receiver/githubactionsreceiver")
+}
+
+func Tracer(settings component.TelemetrySettings) trace.Tracer {
+	return settings.TracerProvider.Tracer("github.com/grafana/grafana-ci-otel-collector/receiver/githubactionsreceiver")
+}

--- a/receiver/githubactionsreceiver/metadata.yaml
+++ b/receiver/githubactionsreceiver/metadata.yaml
@@ -28,6 +28,7 @@ attributes:
       - in_progress
       - queued
       - waiting
+      - aborted
     type: string
   ci.github.workflow.job.conclusion:
     description: Job Conclusion

--- a/receiver/githubactionsreceiver/metric_event_handling.go
+++ b/receiver/githubactionsreceiver/metric_event_handling.go
@@ -52,6 +52,9 @@ func (m *metricsHandler) eventToMetrics(event *github.WorkflowJobEvent) pmetric.
 
 	status, actionOk := metadata.MapAttributeCiGithubWorkflowJobStatus[event.GetAction()]
 	conclusion, conclusionOk := metadata.MapAttributeCiGithubWorkflowJobConclusion[event.GetWorkflowJob().GetConclusion()]
+	if (status == metadata.AttributeCiGithubWorkflowJobStatusCompleted && conclusion == metadata.AttributeCiGithubWorkflowJobConclusionCancelled && len(event.GetWorkflowJob().Steps) == 1) {
+		status = metadata.AttributeCiGithubWorkflowJobStatusAborted
+	}
 	if !conclusionOk {
 		conclusion = metadata.AttributeCiGithubWorkflowJobConclusionNull
 	}


### PR DESCRIPTION
Adds `aborted` status, which is when a workflow starts but gets cancelled before the job is set up. 
This workflow goes straight from `queued` status to `complete`, without being in progress.