### PR TITLE
feat: add `ci.github.workflow.job.head_branch.is_main` boolean attribute

### DIFF
--- a/receiver/githubactionsreceiver/receiver_test.go
+++ b/receiver/githubactionsreceiver/receiver_test.go
@@ -200,7 +200,8 @@ func TestProcessSteps(t *testing.T) {
 			traceID, _ := generateTraceID(123, 1)
 			parentSpanID := createParentSpan(ss, tc.givenSteps, &github.WorkflowJob{}, traceID, logger)
 
-			processSteps(ss, tc.givenSteps, &github.WorkflowJob{}, traceID, parentSpanID, logger)
+			defaultBranch := "main"
+			processSteps(ss, tc.givenSteps, &github.WorkflowJob{}, &defaultBranch, traceID, parentSpanID, logger)
 
 			startIdx := 1 // Skip the parent span if it's the first one
 			if len(tc.expectedStatuses) == 0 {
@@ -264,9 +265,11 @@ func TestResourceAndSpanAttributesCreation(t *testing.T) {
 					}
 
 					isMainValue, found := attrs.Get("ci.github.workflow.job.head_branch.is_main")
-					isMain := isMainValue.Bool()
+					if !found || isMainValue.AsString() == "" { // Skip if the attribute is not found or name is empty
+						continue
+					}
 
-					require.True(t, isMain)
+					require.True(t, isMainValue.Bool())
 
 					expectedStepName := expectedStep["ci.github.workflow.job.step.name"]
 

--- a/receiver/githubactionsreceiver/trace_event_handling.go
+++ b/receiver/githubactionsreceiver/trace_event_handling.go
@@ -34,8 +34,10 @@ func eventToTraces(event interface{}, config *Config, logger *zap.Logger) (*ptra
 			return nil, fmt.Errorf("failed to generate trace ID: %w", err)
 		}
 
+		defaultBranch := e.GetRepo().DefaultBranch
+
 		parentSpanID := createParentSpan(scopeSpans, e.GetWorkflowJob().Steps, e.GetWorkflowJob(), traceID, logger)
-		processSteps(scopeSpans, e.GetWorkflowJob().Steps, e.GetWorkflowJob(), traceID, parentSpanID, logger)
+		processSteps(scopeSpans, e.GetWorkflowJob().Steps, e.GetWorkflowJob(), defaultBranch, traceID, parentSpanID, logger)
 
 	case *github.WorkflowRunEvent:
 		logger.Info("Processing WorkflowRunEvent", zap.Int64("workflow_id", e.GetWorkflowRun().GetID()), zap.String("workflow_name", e.GetWorkflowRun().GetName()), zap.String("repo", e.GetRepo().GetFullName()))
@@ -161,15 +163,14 @@ func createRootSpan(resourceSpans ptrace.ResourceSpans, event *github.WorkflowRu
 	return rootSpanID, nil
 }
 
-func createSpan(scopeSpans ptrace.ScopeSpans, step *github.TaskStep, job *github.WorkflowJob, traceID pcommon.TraceID, parentSpanID pcommon.SpanID, logger *zap.Logger) pcommon.SpanID {
+func createSpan(scopeSpans ptrace.ScopeSpans, step *github.TaskStep, job *github.WorkflowJob, defaultBranch *string, traceID pcommon.TraceID, parentSpanID pcommon.SpanID, logger *zap.Logger) pcommon.SpanID {
 	logger.Debug("Processing span", zap.String("step_name", step.GetName()))
 	span := scopeSpans.Spans().AppendEmpty()
 	span.SetTraceID(traceID)
 	span.SetParentSpanID(parentSpanID)
 
 	var spanID pcommon.SpanID
-	
-	if job.GetHeadBranch() == "main" || job.GetHeadBranch() == "master" {
+	if job.GetHeadBranch() == *defaultBranch {
 		span.Attributes().PutBool("ci.github.workflow.job.head_branch.is_main", true)
 	} else {
 		span.Attributes().PutBool("ci.github.workflow.job.head_branch.is_main", false)
@@ -273,9 +274,9 @@ func generateStepSpanID(runID int64, runAttempt int, jobName string, stepNumber 
 	return spanID, nil
 }
 
-func processSteps(scopeSpans ptrace.ScopeSpans, steps []*github.TaskStep, job *github.WorkflowJob, traceID pcommon.TraceID, parentSpanID pcommon.SpanID, logger *zap.Logger) {
+func processSteps(scopeSpans ptrace.ScopeSpans, steps []*github.TaskStep, job *github.WorkflowJob, defaultBranch *string, traceID pcommon.TraceID, parentSpanID pcommon.SpanID, logger *zap.Logger) {
 	for _, step := range steps {
-		createSpan(scopeSpans, step, job, traceID, parentSpanID, logger)
+		createSpan(scopeSpans, step, job, defaultBranch, traceID, parentSpanID, logger)
 	}
 }
 


### PR DESCRIPTION
Part of: https://github.com/grafana/grafana-ci-otel-collector/issues/177

We need this metric so we can know what's the failure rate in main/master branches of each repo.

The reason why we have a bool which shows if the branch is either `master` or `main` and we don't allow every branch name, is to avoid cardinality explosion.