### PR TITLE
chore: Add dsotirakis as codeowner in the receivers

### DIFF
--- a/receiver/dronereceiver/README.md
+++ b/receiver/dronereceiver/README.md
@@ -7,7 +7,7 @@
 | Stability     | [development]: logs, traces, metrics   |
 | Distributions | [grafana-ci-otel-collector] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fdrone%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fdrone) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fdrone%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fdrone) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Elfo404](https://www.github.com/Elfo404) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Elfo404](https://www.github.com/Elfo404), [@dsotirakis](https://www.github.com/dsotirakis) |
 
 [development]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#development
 [grafana-ci-otel-collector]: 

--- a/receiver/dronereceiver/metadata.yaml
+++ b/receiver/dronereceiver/metadata.yaml
@@ -18,7 +18,7 @@ status:
   distributions:
     - grafana-ci-otel-collector
   codeowners:
-    active: [Elfo404]
+    active: [Elfo404, dsotirakis]
 
 resource_attributes:
 

--- a/receiver/githubactionsreceiver/README.md
+++ b/receiver/githubactionsreceiver/README.md
@@ -6,7 +6,7 @@
 | Stability     | [alpha]: traces, logs, metrics   |
 | Distributions | [grafana-ci-otel-collector] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fgithubactions%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fgithubactions) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fgithubactions%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fgithubactions) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Elfo404](https://www.github.com/Elfo404) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Elfo404](https://www.github.com/Elfo404), [@dsotirakis](https://github.com/dsotirakis) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#alpha
 [grafana-ci-otel-collector]: 

--- a/receiver/githubactionsreceiver/README.md
+++ b/receiver/githubactionsreceiver/README.md
@@ -6,7 +6,7 @@
 | Stability     | [alpha]: traces, logs, metrics   |
 | Distributions | [grafana-ci-otel-collector] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fgithubactions%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fgithubactions) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fgithubactions%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fgithubactions) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Elfo404](https://www.github.com/Elfo404) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Elfo404](https://www.github.com/Elfo404), [@dsotirakis](https://www.github.com/dsotirakis) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#alpha
 [grafana-ci-otel-collector]: 

--- a/receiver/githubactionsreceiver/README.md
+++ b/receiver/githubactionsreceiver/README.md
@@ -6,7 +6,7 @@
 | Stability     | [alpha]: traces, logs, metrics   |
 | Distributions | [grafana-ci-otel-collector] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fgithubactions%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fgithubactions) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fgithubactions%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fgithubactions) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Elfo404](https://www.github.com/Elfo404), [@dsotirakis](https://github.com/dsotirakis) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Elfo404](https://www.github.com/Elfo404) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#alpha
 [grafana-ci-otel-collector]: 

--- a/receiver/githubactionsreceiver/metadata.yaml
+++ b/receiver/githubactionsreceiver/metadata.yaml
@@ -9,7 +9,7 @@ status:
   distributions:
     - grafana-ci-otel-collector
   codeowners:
-    active: [Elfo404]
+    active: [Elfo404, dsotirakis]
     emeritus:
 
 resource_attributes:


### PR DESCRIPTION
Adds `dsotirakis` handle in the `githubactionsreceiver` and `dronereceiver` codeowners section.