### PR TITLE
chore: add `nil` check and debug message in `is_main` functionality

### DIFF
--- a/receiver/githubactionsreceiver/trace_event_handling.go
+++ b/receiver/githubactionsreceiver/trace_event_handling.go
@@ -174,9 +174,10 @@ func createSpan(scopeSpans ptrace.ScopeSpans, step *github.TaskStep, job *github
 	span.SetParentSpanID(parentSpanID)
 
 	var spanID pcommon.SpanID
-	if job.GetHeadBranch() == *defaultBranch {
-		span.Attributes().PutBool("ci.github.workflow.job.head_branch.is_main", true)
+	if defaultBranch != nil {
+		span.Attributes().PutBool("ci.github.workflow.job.head_branch.is_main", job.GetHeadBranch() == *defaultBranch)
 	} else {
+		logger.Debug("Default branch is nil, setting is_main to false")
 		span.Attributes().PutBool("ci.github.workflow.job.head_branch.is_main", false)
 	}
 


### PR DESCRIPTION
nit: Adds `nil` check for the current branch to prevent panics. Also, adds a debug message.