### PR TITLE
ci(go): restore inexact go caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
             ./.tools
-          key: go-cache-${{ hashFiles('**/go.sum') }}
+          key: go-cache-${{ runner.OS }}-${{ runner.ARCH }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-cache-${{ runner.OS }}-${{ runner.ARCH }}-
 
       - name: Make install-tools
         if: steps.cache.outputs.cache-hit != 'true'
@@ -70,7 +72,9 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
             ./.tools
-          key: go-cache-${{ hashFiles('**/go.sum') }}
+          key: go-cache-${{ runner.OS }}-${{ runner.ARCH }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-cache-${{ runner.OS }}-${{ runner.ARCH }}-
           fail-on-cache-miss: true
 
       - name: Check packages are up-to-date
@@ -124,7 +128,9 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
             ./.tools
-          key: go-cache-${{ hashFiles('**/go.sum') }}
+          key: go-cache-${{ runner.OS }}-${{ runner.ARCH }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-cache-${{ runner.OS }}-${{ runner.ARCH }}-
           fail-on-cache-miss: true
 
       - name: Make test-all


### PR DESCRIPTION
We have caching for the Go toolchain and dependencies at the minute. But the cache key is the hash of the `go.sum` file, and so the cache isn't used whenever this is updated.

CI can take up to 10 minutes to run, a decent chunk of which is installing dependencies. When we get a lot of Dependabot bumps at once it can be a bit tedious to have to wait for all of them, especially when they need to rebase multiple times.

The `actions/cache` action which we use has a `restore-keys` option, which allows us to specify a list of keys to use when restoring cache. You write your cache key as a hierarchy, and the action will restore the closest one which matches.

This means in our case we include the runner OS and CPU architecture in the key. If the exact match isn't found, we restore the latest cache we have for this OS/arch combo. The hope is that some cache is better than no cache and we'll get a speedup for dependency-changing builds.
