### PR TITLE
self-metrics: Add `cicd_o11y_build_info` metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ endif
 
 .PHONY: build
 build: install-tools
-	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 $(OCB) --config config/manifest.yaml
+	VERSION="$$(git rev-parse HEAD)" && \
+	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 $(OCB) --config config/manifest.yaml --ldflags "-X github.com/prometheus/common/version.Version=$${VERSION}"
 
 .PHONY: build-debug
 build-debug: install-tools

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/prometheus/common v0.63.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFu
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus/common v0.63.0 h1:YR/EIY1o3mEFP/kZCD7iDMnLPlGyuU2Gb3HIcXnA98k=
+github.com/prometheus/common v0.63.0/go.mod h1:VVFF/fBIoToEnWRVkYoXEkq3R3paCoxG9PXP74SnV18=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=

--- a/receiver/githubactionsreceiver/documentation.md
+++ b/receiver/githubactionsreceiver/documentation.md
@@ -12,6 +12,20 @@ metrics:
     enabled: false
 ```
 
+### build.info
+
+Build info.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {build} | Sum | Int | Cumulative | true |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| version | The version of the cicd_o11y collector. | Any Str |
+
 ### workflow.jobs.count
 
 Number of jobs.

--- a/receiver/githubactionsreceiver/documentation.md
+++ b/receiver/githubactionsreceiver/documentation.md
@@ -16,9 +16,9 @@ metrics:
 
 Build info.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {build} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {build} | Gauge | Int |
 
 #### Attributes
 

--- a/receiver/githubactionsreceiver/go.mod
+++ b/receiver/githubactionsreceiver/go.mod
@@ -24,7 +24,7 @@ require (
 	go.uber.org/zap v1.27.0
 )
 
-require github.com/prometheus/common v0.63.0 // indirect
+require github.com/prometheus/common v0.63.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/receiver/githubactionsreceiver/go.mod
+++ b/receiver/githubactionsreceiver/go.mod
@@ -24,6 +24,8 @@ require (
 	go.uber.org/zap v1.27.0
 )
 
+require github.com/prometheus/common v0.63.0 // indirect
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/receiver/githubactionsreceiver/go.sum
+++ b/receiver/githubactionsreceiver/go.sum
@@ -245,6 +245,8 @@ github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6T
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
+github.com/prometheus/common v0.63.0 h1:YR/EIY1o3mEFP/kZCD7iDMnLPlGyuU2Gb3HIcXnA98k=
+github.com/prometheus/common v0.63.0/go.mod h1:VVFF/fBIoToEnWRVkYoXEkq3R3paCoxG9PXP74SnV18=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=

--- a/receiver/githubactionsreceiver/internal/metadata/generated_config.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_config.go
@@ -27,12 +27,16 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for githubactions metrics.
 type MetricsConfig struct {
+	BuildInfo         MetricConfig `mapstructure:"build.info"`
 	WorkflowJobsCount MetricConfig `mapstructure:"workflow.jobs.count"`
 	WorkflowRunsCount MetricConfig `mapstructure:"workflow.runs.count"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
+		BuildInfo: MetricConfig{
+			Enabled: true,
+		},
 		WorkflowJobsCount: MetricConfig{
 			Enabled: true,
 		},

--- a/receiver/githubactionsreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_config_test.go
@@ -25,6 +25,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					BuildInfo:         MetricConfig{Enabled: true},
 					WorkflowJobsCount: MetricConfig{Enabled: true},
 					WorkflowRunsCount: MetricConfig{Enabled: true},
 				},
@@ -34,6 +35,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					BuildInfo:         MetricConfig{Enabled: false},
 					WorkflowJobsCount: MetricConfig{Enabled: false},
 					WorkflowRunsCount: MetricConfig{Enabled: false},
 				},

--- a/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
@@ -198,17 +198,15 @@ func (m *metricBuildInfo) init() {
 	m.data.SetName("build.info")
 	m.data.SetDescription("Build info.")
 	m.data.SetUnit("{build}")
-	m.data.SetEmptySum()
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
 func (m *metricBuildInfo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, versionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntValue(val)
@@ -217,14 +215,14 @@ func (m *metricBuildInfo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Ti
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricBuildInfo) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBuildInfo) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()

--- a/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
@@ -187,6 +187,59 @@ var MapAttributeCiGithubWorkflowRunStatus = map[string]AttributeCiGithubWorkflow
 	"aborted":     AttributeCiGithubWorkflowRunStatusAborted,
 }
 
+type metricBuildInfo struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	config   MetricConfig   // metric config provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills build.info metric with initial data.
+func (m *metricBuildInfo) init() {
+	m.data.SetName("build.info")
+	m.data.SetDescription("Build info.")
+	m.data.SetUnit("{build}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricBuildInfo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, versionAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+	dp.Attributes().PutStr("version", versionAttributeValue)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricBuildInfo) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricBuildInfo) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricBuildInfo(cfg MetricConfig) metricBuildInfo {
+	m := metricBuildInfo{config: cfg}
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricWorkflowJobsCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	config   MetricConfig   // metric config provided by user.
@@ -309,6 +362,7 @@ type MetricsBuilder struct {
 	metricsCapacity         int                  // maximum observed number of metrics per resource.
 	metricsBuffer           pmetric.Metrics      // accumulates metrics data before emitting.
 	buildInfo               component.BuildInfo  // contains version information.
+	metricBuildInfo         metricBuildInfo
 	metricWorkflowJobsCount metricWorkflowJobsCount
 	metricWorkflowRunsCount metricWorkflowRunsCount
 }
@@ -336,6 +390,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		startTime:               pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:           pmetric.NewMetrics(),
 		buildInfo:               settings.BuildInfo,
+		metricBuildInfo:         newMetricBuildInfo(mbc.Metrics.BuildInfo),
 		metricWorkflowJobsCount: newMetricWorkflowJobsCount(mbc.Metrics.WorkflowJobsCount),
 		metricWorkflowRunsCount: newMetricWorkflowRunsCount(mbc.Metrics.WorkflowRunsCount),
 	}
@@ -403,6 +458,7 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	ils.Scope().SetName("github.com/grafana/grafana-ci-otel-collector/receiver/githubactionsreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricBuildInfo.emit(ils.Metrics())
 	mb.metricWorkflowJobsCount.emit(ils.Metrics())
 	mb.metricWorkflowRunsCount.emit(ils.Metrics())
 
@@ -424,6 +480,11 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 	metrics := mb.metricsBuffer
 	mb.metricsBuffer = pmetric.NewMetrics()
 	return metrics
+}
+
+// RecordBuildInfoDataPoint adds a data point to build.info metric.
+func (mb *MetricsBuilder) RecordBuildInfoDataPoint(ts pcommon.Timestamp, val int64, versionAttributeValue string) {
+	mb.metricBuildInfo.recordDataPoint(mb.startTime, ts, val, versionAttributeValue)
 }
 
 // RecordWorkflowJobsCountDataPoint adds a data point to workflow.jobs.count metric.

--- a/receiver/githubactionsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_metrics_test.go
@@ -96,13 +96,11 @@ func TestMetricsBuilder(t *testing.T) {
 				case "build.info":
 					assert.False(t, validatedMetrics["build.info"], "Found a duplicate in the metrics slice: build.info")
 					validatedMetrics["build.info"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
 					assert.Equal(t, "Build info.", ms.At(i).Description())
 					assert.Equal(t, "{build}", ms.At(i).Unit())
-					assert.True(t, ms.At(i).Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
-					dp := ms.At(i).Sum().DataPoints().At(0)
+					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())

--- a/receiver/githubactionsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/githubactionsreceiver/internal/metadata/testdata/config.yaml
@@ -1,12 +1,16 @@
 default:
 all_set:
   metrics:
+    build.info:
+      enabled: true
     workflow.jobs.count:
       enabled: true
     workflow.runs.count:
       enabled: true
 none_set:
   metrics:
+    build.info:
+      enabled: false
     workflow.jobs.count:
       enabled: false
     workflow.runs.count:

--- a/receiver/githubactionsreceiver/metadata.yaml
+++ b/receiver/githubactionsreceiver/metadata.yaml
@@ -72,6 +72,9 @@ attributes:
   ci.github.workflow.run.head_branch.is_main:
     description: Whether the head branch is the main branch
     type: bool
+  version:
+    description: The version of the cicd_o11y collector.
+    type: string
 
 metrics:
   workflow.jobs.count:
@@ -105,4 +108,16 @@ metrics:
         ci.github.workflow.run.status,
         ci.github.workflow.run.conclusion,
         ci.github.workflow.run.head_branch.is_main,
+      ]
+  build.info:
+    enabled: true
+    description: Build info.
+    unit: "{build}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      [
+        version,
       ]

--- a/receiver/githubactionsreceiver/metadata.yaml
+++ b/receiver/githubactionsreceiver/metadata.yaml
@@ -113,10 +113,8 @@ metrics:
     enabled: true
     description: Build info.
     unit: "{build}"
-    sum:
+    gauge:
       value_type: int
-      monotonic: true
-      aggregation_temporality: cumulative
     attributes:
       [
         version,


### PR DESCRIPTION
Adding `cicd_o11y_build_info` metric, to use an automated CD process in Argo Workflows.

Since our collector uses `prometheusexporter`, we cannot use native prometheus here and we should expose this metric using the otel collector itself.

Part of: https://github.com/grafana/deployment_tools/issues/249739

------

Working example, after trying on dev:

![image](https://github.com/user-attachments/assets/673e96b5-aacf-4e0e-86a1-75e8d397173f)
