### PR TITLE
feat: add ec2 instance id to GitHub trace metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,9 +151,10 @@ jobs:
         uses: grafana/shared-workflows/actions/push-to-gar-docker@main
         with:
           # Only push to GAR on main branch pushes
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref_name == 'main' && 'true' || 'false' }}
           tags: |-
-            "rickytest"
+            ${{ github.sha }}
+            "latest"
           context: "."
           image_name: "grafana-ci-otel-collector"
           environment: "dev"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,10 +151,9 @@ jobs:
         uses: grafana/shared-workflows/actions/push-to-gar-docker@main
         with:
           # Only push to GAR on main branch pushes
-          push: ${{ github.event_name == 'push' && github.ref_name == 'main' && 'true' || 'false' }}
+          push: true
           tags: |-
-            ${{ github.sha }}
-            "latest"
+            "rickytest"
           context: "."
           image_name: "grafana-ci-otel-collector"
           environment: "dev"

--- a/receiver/githubactionsreceiver/trace_attributes.go
+++ b/receiver/githubactionsreceiver/trace_attributes.go
@@ -52,6 +52,11 @@ func createResourceAttributes(resource pcommon.Resource, event interface{}, conf
 		attrs.PutStr("ci.github.workflow.job.started_at", e.GetWorkflowJob().GetStartedAt().Format(time.RFC3339))
 		attrs.PutStr("ci.github.workflow.job.status", e.GetWorkflowJob().GetStatus())
 
+		// Grafana self-hosted runners have a Group Name of default
+		if strings.ToLower(e.GetWorkflowJob().GetRunnerGroupName()) == "default" {
+			attrs.PutStr("ci.github.workflow.job.runner.ec2_instance_id", strings.Split(e.GetWorkflowJob().GetRunnerName(), "_")[1])
+		}
+
 		attrs.PutStr("ci.system", "github")
 
 		attrs.PutStr("scm.git.repo.owner.login", e.GetRepo().GetOwner().GetLogin())


### PR DESCRIPTION
This will extract an ec2 instance id from Grafana's self-hosted runner's if the runner's group name is set to "default" (case insensitive). 

Goes with https://github.com/grafana/deployment_tools/pull/251705