### PR TITLE
Add otlphttp dep & build custom test image via branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         uses: grafana/shared-workflows/actions/push-to-gar-docker@main
         with:
           # Only push to GAR on main branch pushes
-          push: ${{ github.event_name == 'push' && github.ref_name == 'main' && 'true' || 'false' }}
+          push: true
           tags: |-
             "phlope-otlphttp-test"
           context: "."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,7 @@ jobs:
           # Only push to GAR on main branch pushes
           push: ${{ github.event_name == 'push' && github.ref_name == 'main' && 'true' || 'false' }}
           tags: |-
-            ${{ github.sha }}
-            "latest"
+            "phlope-otlphttp-test"
           context: "."
           image_name: "grafana-ci-otel-collector"
           environment: "dev"

--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -9,6 +9,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.120.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.120.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.120.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.120.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.120.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.120.0
 


### PR DESCRIPTION
PR to test the use of the otlphttp exporter for the cicd-o11y logs ingestion pipeline
First draft set to install the new dependency & build a dev image `phlope-otlphttp-test` for dev env testing locally