### PR TITLE
feat: Adding PR comment context as a flag to argo workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,8 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' && true || false }}
         name: Extract PR number
         env:
-          PR: ${{ steps.find-commit-pr && fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
-          FIRST_COMMIT_TS: ${{ steps.find-commit-pr && fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.commits.edges[0].node.commit.committedDate }}
+          PR: ${{ steps.find-commit-pr.outputs.data && fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
+          FIRST_COMMIT_TS: ${{ steps.find-commit-pr.outputs.data && fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.commits.edges[0].node.commit.committedDate }}
         run: |
           if [ -z "${PR}" ]; then
             echo "No PR found, skipping..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,11 +214,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - id: extract-pr-number
-        # if: ${{ github.event_name == 'push' && github.ref_name == 'main' && true || false }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' && true || false }}
         name: Extract PR number
         env:
-          PR: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
-          FIRST_COMMIT_TS: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.commits.edges[0].node.commit.committedDate }}
+          PR: ${{ steps.find-commit-pr && fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
+          FIRST_COMMIT_TS: ${{ steps.find-commit-pr && fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.commits.edges[0].node.commit.committedDate }}
         run: |
           if [ -z "${PR}" ]; then
             echo "No PR found, skipping..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,62 @@ jobs:
             GITHUB_APP_ID=updater-app:app-id
             GITHUB_APP_INSTALLATION_ID=updater-app:app-installation-id
             GITHUB_APP_PRIVATE_KEY=updater-app:private-key
+      
+      - id: find-commit-pr
+        uses: octokit/graphql-action@8ad880e4d437783ea2ab17010324de1075228110 # v2.3.2
+        name: Find PR for commit
+        with:
+          query: |
+            query associatedPRs($sha: String, $repo: String!, $owner: String!) {
+              repository(name: $repo, owner: $owner) {
+                object(expression: $sha) {
+                ... on Commit {
+                    associatedPullRequests(first: 5) {
+                      edges {
+                        node {
+                          number
+                          commits(first: 1) {
+                            edges {
+                              node {
+                                commit {
+                                  committedDate
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          variables: |
+            owner: ${{ github.event.repository.owner.name }}
+            repo: ${{ github.event.repository.name }}
+            sha: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: extract-pr-number
+        name: Extract PR number
+        env:
+          PR: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
+          FIRST_COMMIT_TS: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.commits.edges[0].node.commit.committedDate }}
+        run: |
+          if [ -z "${PR}" ]; then
+            echo "No PR found, skipping..."
+            echo "contextMessage=\"\"" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "This commit was from PR ${PR}"
+
+          echo "contextMessage= This deployment was triggered by [this pull request](https://github.com/${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}/pull/${PR})." >> "${GITHUB_OUTPUT}"
+          echo "number=${PR}" >> "${GITHUB_OUTPUT}"
+          TS=$(date -u --date ${FIRST_COMMIT_TS} +'%s')
+          echo "first-commit-ts=${TS}" >> "${GITHUB_OUTPUT}"
+          cat "${GITHUB_OUTPUT}"
 
       - id: 'submit-argowfs-deployment'
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' && true || false }}
@@ -185,3 +241,4 @@ jobs:
           workflow_template: 'cicd-o11y'
           parameters: |
             dockertag=${{ github.sha }}
+            prCommentContext=${{ steps.extract-pr-number.outputs.contextMessage }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
             GITHUB_APP_PRIVATE_KEY=updater-app:private-key
       
       - id: find-commit-pr
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' && true || false }}
         uses: octokit/graphql-action@8ad880e4d437783ea2ab17010324de1075228110 # v2.3.2
         name: Find PR for commit
         with:
@@ -206,13 +207,14 @@ jobs:
               }
             }
           variables: |
-            owner: ${{ github.repository_owner}}
+            owner: ${{ github.repository_owner }}
             repo: ${{ github.event.repository.name }}
             sha: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - id: extract-pr-number
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' && true || false }}
         name: Extract PR number
         env:
           PR: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
@@ -223,7 +225,7 @@ jobs:
             echo "contextMessage=\"\"" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
-
+          
           echo "This commit was from PR ${PR}"
 
           echo "contextMessage= This deployment was triggered by [this pull request](https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/pull/${PR})." >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,8 +225,8 @@ jobs:
       - id: extract-pr-number
         name: Extract PR number
         env:
-          PR: ${{ steps.find-commit-pr.outputs.data && fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
-          FIRST_COMMIT_TS: ${{ steps.find-commit-pr.outputs.data && fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.commits.edges[0].node.commit.committedDate }}
+          PR: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
+          FIRST_COMMIT_TS: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.commits.edges[0].node.commit.committedDate }}
         run: |
           if [ -z "${PR}" ]; then
             echo "No PR found, skipping..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,9 +175,18 @@ jobs:
             GITHUB_APP_ID=updater-app:app-id
             GITHUB_APP_INSTALLATION_ID=updater-app:app-installation-id
             GITHUB_APP_PRIVATE_KEY=updater-app:private-key
-      
+  
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref_name == 'main' && true || false }}
+    needs:
+      - lint
+      - test
+      - build-and-push
+    
+    steps:
       - id: find-commit-pr
-        if: ${{ github.event_name == 'push' && github.ref_name == 'main' && true || false }}
         uses: octokit/graphql-action@8ad880e4d437783ea2ab17010324de1075228110 # v2.3.2
         name: Find PR for commit
         with:
@@ -214,7 +223,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - id: extract-pr-number
-        if: ${{ github.event_name == 'push' && github.ref_name == 'main' && true || false }}
         name: Extract PR number
         env:
           PR: ${{ steps.find-commit-pr.outputs.data && fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - id: extract-pr-number
-        if: ${{ github.event_name == 'push' && github.ref_name == 'main' && true || false }}
+        # if: ${{ github.event_name == 'push' && github.ref_name == 'main' && true || false }}
         name: Extract PR number
         env:
           PR: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
               }
             }
           variables: |
-            owner: ${{ github.event.repository.owner.name }}
+            owner: ${{ github.repository_owner}}
             repo: ${{ github.event.repository.name }}
             sha: ${{ github.sha }}
         env:
@@ -226,7 +226,7 @@ jobs:
 
           echo "This commit was from PR ${PR}"
 
-          echo "contextMessage= This deployment was triggered by [this pull request](https://github.com/${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}/pull/${PR})." >> "${GITHUB_OUTPUT}"
+          echo "contextMessage= This deployment was triggered by [this pull request](https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/pull/${PR})." >> "${GITHUB_OUTPUT}"
           echo "number=${PR}" >> "${GITHUB_OUTPUT}"
           TS=$(date -u --date ${FIRST_COMMIT_TS} +'%s')
           echo "first-commit-ts=${TS}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Currently in the auto-generated PRs in `deployment_tools`, the link to the code review PR that triggered the workflow is missing. Adding a change, so that the resulting generated PRs look something like this [instead](https://github.com/grafana/deployment_tools/pull/250089).