### PR TITLE
chore(build): consolidate duplicate replace sections in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,10 @@ replace github.com/grafana/grafana-ci-otel-collector/internal/semconv => ./inter
 
 replace github.com/grafana/grafana-ci-otel-collector/internal/sharedcomponent => ./internal/sharedcomponent
 
-require github.com/grafana/grafana-ci-otel-collector/receiver/dronereceiver v0.0.0-00010101000000-000000000000
-
-require github.com/grafana/grafana-ci-otel-collector/receiver/githubactionsreceiver v0.0.0-00010101000000-000000000000
+require (
+	github.com/grafana/grafana-ci-otel-collector/receiver/dronereceiver v0.0.0-00010101000000-000000000000
+	github.com/grafana/grafana-ci-otel-collector/receiver/githubactionsreceiver v0.0.0-00010101000000-000000000000
+)
 
 require (
 	github.com/99designs/httpsignatures-go v0.0.0-20170731043157-88528bf4ca7e // indirect

--- a/receiver/githubactionsreceiver/go.mod
+++ b/receiver/githubactionsreceiver/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v62 v62.0.0
 	github.com/grafana/grafana-ci-otel-collector/internal/sharedcomponent v0.0.0-00010101000000-000000000000
+	github.com/prometheus/common v0.63.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.120.0
 	go.opentelemetry.io/collector/component/componenttest v0.120.0
@@ -24,10 +25,6 @@ require (
 	go.uber.org/zap v1.27.0
 )
 
-require github.com/prometheus/common v0.63.0
-
-require github.com/google/go-github/v71 v71.0.0 // indirect
-
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -38,6 +35,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/go-github/v71 v71.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect


### PR DESCRIPTION
Noticed there are multiple and that shouldn't happen. I think that `go mod tidy` has an issue which sometimes does this but I've never managed to make it happen reliably.
