### PR TITLE
feat: Add otlphttp 0.120.0 dependency

### DIFF
--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -9,6 +9,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.120.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.120.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.120.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.120.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.120.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.120.0
 


### PR DESCRIPTION
Adding `otlphttpexporter` to our manifest dependencies for use in the the cicd-o11y logs ingestion pipeline following deprecation of the loki exporter

Source issue: https://github.com/grafana/deployment_tools/issues/231125
