### PR TITLE
deps: bump `otlphttp` exporter to 0.125.0

### DIFF
--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -9,7 +9,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.125.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.125.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.125.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.120.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.125.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.125.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.125.0
 


### PR DESCRIPTION
Leftover after: https://github.com/grafana/grafana-ci-otel-collector/pull/257