### PR TITLE
bug: fix workflow.jobs.count duplication

### DIFF
--- a/receiver/githubactionsreceiver/metric_event_handling.go
+++ b/receiver/githubactionsreceiver/metric_event_handling.go
@@ -1,6 +1,7 @@
 package githubactionsreceiver
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -21,6 +22,8 @@ type metricsHandler struct {
 	mb       *metadata.MetricsBuilder
 	cfg      *Config
 	logger   *zap.Logger
+	// Track what we've recorded in current emission to prevent duplicates
+	recordedInThisEmission sync.Map // key: string, value: bool
 }
 
 var repoMap = sync.Map{}
@@ -95,27 +98,32 @@ func (m *metricsHandler) workflowJobEventToMetrics(event *github.WorkflowJobEven
 	if actionOk {
 		curVal, found := loadFromCache(repo, labels, status, conclusion)
 
-		// If the value was not found in the cache, we record a 0 value for all other possible statuses
-		// so that all counters for a given labels combination are always present and reset at the same time.
-		if !found {
-			for _, s := range metadata.MapAttributeCiGithubWorkflowJobStatus {
-				for _, c := range metadata.MapAttributeCiGithubWorkflowJobConclusion {
-					if s == status && c == conclusion {
-						continue
+		metricKey := fmt.Sprintf("job:%s:%s:%s:%s:%t", repo, labels, status.String(), conclusion.String(), isMain)
+
+		if _, alreadyRecorded := m.recordedInThisEmission.LoadOrStore(metricKey, true); !alreadyRecorded {
+			if !found {
+				for _, s := range metadata.MapAttributeCiGithubWorkflowJobStatus {
+					for _, c := range metadata.MapAttributeCiGithubWorkflowJobConclusion {
+						if s == status && c == conclusion {
+							continue
+						}
+						storeInCache(repo, labels, s, c, 0)
+						otherKey := fmt.Sprintf("job:%s:%s:%s:%s:%t", repo, labels, s.String(), c.String(), isMain)
+						if _, recorded := m.recordedInThisEmission.LoadOrStore(otherKey, true); !recorded {
+							m.mb.RecordWorkflowJobsCountDataPoint(now, 0, repo, labels, s, c, isMain)
+						}
 					}
-
-					storeInCache(repo, labels, s, c, 0)
-					m.mb.RecordWorkflowJobsCountDataPoint(now, 0, repo, labels, s, c, isMain)
 				}
-
 			}
+			storeInCache(repo, labels, status, conclusion, curVal+1)
+			m.mb.RecordWorkflowJobsCountDataPoint(now, curVal+1, repo, labels, status, conclusion, isMain)
 		}
-
-		storeInCache(repo, labels, status, conclusion, curVal+1)
-		m.mb.RecordWorkflowJobsCountDataPoint(now, curVal+1, repo, labels, status, conclusion, isMain)
 	}
 
-	return m.mb.Emit()
+	result := m.mb.Emit()
+	// Clear the recorded tracking for next emission
+	m.recordedInThisEmission = sync.Map{}
+	return result
 }
 
 func (m *metricsHandler) workflowRunEventToMetrics(event *github.WorkflowRunEvent) pmetric.Metrics {
@@ -148,27 +156,32 @@ func (m *metricsHandler) workflowRunEventToMetrics(event *github.WorkflowRunEven
 	if actionOk {
 		curVal, found := loadFromCache(repo, "default", status, conclusion)
 
-		// If the value was not found in the cache, we record a 0 value for all other possible statuses
-		// so that all counters for a given labels combination are always present and reset at the same time.
-		if !found {
-			for _, s := range metadata.MapAttributeCiGithubWorkflowRunStatus {
-				for _, c := range metadata.MapAttributeCiGithubWorkflowRunConclusion {
-					if s == status && c == conclusion {
-						continue
+		metricKey := fmt.Sprintf("run:%s:%s:%s:%s:%t", repo, "default", status.String(), conclusion.String(), isMain)
+
+		if _, alreadyRecorded := m.recordedInThisEmission.LoadOrStore(metricKey, true); !alreadyRecorded {
+			if !found {
+				for _, s := range metadata.MapAttributeCiGithubWorkflowRunStatus {
+					for _, c := range metadata.MapAttributeCiGithubWorkflowRunConclusion {
+						if s == status && c == conclusion {
+							continue
+						}
+						storeInCache(repo, "default", s, c, 0)
+						otherKey := fmt.Sprintf("run:%s:%s:%s:%s:%t", repo, "default", s.String(), c.String(), isMain)
+						if _, recorded := m.recordedInThisEmission.LoadOrStore(otherKey, true); !recorded {
+							m.mb.RecordWorkflowRunsCountDataPoint(now, 0, repo, "default", s, c, isMain)
+						}
 					}
-
-					storeInCache(repo, "default", s, c, 0)
-					m.mb.RecordWorkflowRunsCountDataPoint(now, 0, repo, "default", s, c, isMain)
 				}
-
 			}
+			storeInCache(repo, "default", status, conclusion, curVal+1)
+			m.mb.RecordWorkflowRunsCountDataPoint(now, curVal+1, repo, "default", status, conclusion, isMain)
 		}
-
-		storeInCache(repo, "default", status, conclusion, curVal+1)
-		m.mb.RecordWorkflowRunsCountDataPoint(now, curVal+1, repo, "default", status, conclusion, isMain)
 	}
 
-	return m.mb.Emit()
+	result := m.mb.Emit()
+	// Clear the recorded tracking for next emission
+	m.recordedInThisEmission = sync.Map{}
+	return result
 }
 
 func storeInCache(repo, labels string, status interface{}, conclusion interface{}, value int64) {


### PR DESCRIPTION
We were getting messages like: 
`collected metric 'cicd_o11y_workflow_jobs_count' was collected before with the same name and label values`
or
`failed to convert metric workflow.jobs.count: duplicate label names in constant and variable labels for metric \"cicd_o11y_workflow_jobs_count\""`

This occurred because the OpenTelemetry MetricsBuilder was receiving multiple data points with identical label combinations within a single emission cycle.

Fixed it using a `sync.Map` and created unique keys for each metric combination so it can only record each unique combination once per emission.

Tested on dev, no such errors in the last 12h. 