### PR TITLE
bug: fix logs downloading due to wrong format

### DIFF
--- a/receiver/githubactionsreceiver/receiver.go
+++ b/receiver/githubactionsreceiver/receiver.go
@@ -286,6 +286,9 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		} else {
 			withTraceInfo := gar.tracesConsumer != nil && !traceErr
 
+			gar.logger.Debug("Calling eventToLogs")
+			gar.logger.Debug("Event type being passed to eventToLogs", zap.String("event_type", fmt.Sprintf("%T", event)))
+
 			ld, err := eventToLogs(event, gar.config, gar.ghClient, gar.logger.Named("eventToLogs"), withTraceInfo)
 			if err != nil {
 				gar.logger.Error("Failed to process logs", zap.Error(err))


### PR DESCRIPTION
Since ~10 days ago we stopped receiving logs in `cicd-o11y` namespace. We tried many different solutions, from fixing some NPEs (which we should fix anyway 😅 ), to challenging loki failures but nothing worked.

Then we dug a bit deeper and found that there was an issue with the way that the log files get downloaded. Up to now, the files we received were actually directories. So the old logic:

```go
if f.FileInfo().IsDir() {
			// Old format: directories
			jobs = append(jobs, strings.TrimSuffix(f.Name, "/"))
		}
```
worked without issues.

Without a clear notice, or without [any clear docs](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#download-workflow-run-logs), this behavior changed and instead of getting directories, we now started getting files in a `dir/filename.txt` format. In this PR we make this change to basically accept both, in case GitHub goes back to the old way of doing this again without further notice.

Together with the fix, we are adding some debug logs, in order to know where to look if the same thing happens again.

We should first test this on dev and then move to prod once we make sure it works.
