### PR TITLE
feat(githubactionsreceiver): Add `renovate.prs.count` metric

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,10 +161,9 @@ jobs:
         uses: grafana/shared-workflows/actions/push-to-gar-docker@751820b271417d91fe8588816ed4296b311caa33 # v0.5.1
         with:
           # Only push to GAR on main branch pushes
-          push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          push: true
           tags: |-
-            ${{ github.sha }}
-            "latest"
+            "renovate-prs-count"
           context: "."
           image_name: "grafana-ci-otel-collector"
           environment: "dev"

--- a/receiver/githubactionsreceiver/documentation.md
+++ b/receiver/githubactionsreceiver/documentation.md
@@ -41,7 +41,6 @@ Number of Renovate pull requests.
 | vcs.repository.name | Repository name | Any Str |
 | ci.github.pr.state | Pull request state | Str: ``open``, ``closed`` |
 | ci.github.pr.target_branch.is_main | Whether the PR target branch is the main branch | Any Bool |
-| ci.github.pr.number | Pull request number | Any Int |
 
 ### workflow.jobs.count
 

--- a/receiver/githubactionsreceiver/documentation.md
+++ b/receiver/githubactionsreceiver/documentation.md
@@ -26,6 +26,24 @@ Build info.
 | ---- | ----------- | ------ |
 | version | The version of the cicd_o11y collector. | Any Str |
 
+### renovate.prs.count
+
+Number of Renovate pull requests.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {pr} | Sum | Int | Cumulative | true |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| vcs.repository.name | Repository name | Any Str |
+| ci.github.pr.author | Pull request author | Any Str |
+| ci.github.pr.state | Pull request state | Str: ``open``, ``closed`` |
+| ci.github.pr.is_renovate | Whether the PR is created by Renovate | Any Bool |
+| ci.github.pr.target_branch.is_main | Whether the PR target branch is the main branch | Any Bool |
+
 ### workflow.jobs.count
 
 Number of jobs.

--- a/receiver/githubactionsreceiver/documentation.md
+++ b/receiver/githubactionsreceiver/documentation.md
@@ -39,10 +39,9 @@ Number of Renovate pull requests.
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | vcs.repository.name | Repository name | Any Str |
-| ci.github.pr.author | Pull request author | Any Str |
 | ci.github.pr.state | Pull request state | Str: ``open``, ``closed`` |
-| ci.github.pr.is_renovate | Whether the PR is created by Renovate | Any Bool |
 | ci.github.pr.target_branch.is_main | Whether the PR target branch is the main branch | Any Bool |
+| ci.github.pr.number | Pull request number | Any Int |
 
 ### workflow.jobs.count
 

--- a/receiver/githubactionsreceiver/internal/metadata/generated_config.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_config.go
@@ -28,6 +28,7 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 // MetricsConfig provides config for githubactions metrics.
 type MetricsConfig struct {
 	BuildInfo         MetricConfig `mapstructure:"build.info"`
+	RenovatePrsCount  MetricConfig `mapstructure:"renovate.prs.count"`
 	WorkflowJobsCount MetricConfig `mapstructure:"workflow.jobs.count"`
 	WorkflowRunsCount MetricConfig `mapstructure:"workflow.runs.count"`
 }
@@ -35,6 +36,9 @@ type MetricsConfig struct {
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		BuildInfo: MetricConfig{
+			Enabled: true,
+		},
+		RenovatePrsCount: MetricConfig{
 			Enabled: true,
 		},
 		WorkflowJobsCount: MetricConfig{

--- a/receiver/githubactionsreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_config_test.go
@@ -28,6 +28,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
 					BuildInfo:         MetricConfig{Enabled: true},
+					RenovatePrsCount:  MetricConfig{Enabled: true},
 					WorkflowJobsCount: MetricConfig{Enabled: true},
 					WorkflowRunsCount: MetricConfig{Enabled: true},
 				},
@@ -38,6 +39,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
 					BuildInfo:         MetricConfig{Enabled: false},
+					RenovatePrsCount:  MetricConfig{Enabled: false},
 					WorkflowJobsCount: MetricConfig{Enabled: false},
 					WorkflowRunsCount: MetricConfig{Enabled: false},
 				},

--- a/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
@@ -307,7 +307,7 @@ func (m *metricRenovatePrsCount) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricRenovatePrsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryNameAttributeValue string, ciGithubPrAuthorAttributeValue string, ciGithubPrStateAttributeValue string, ciGithubPrIsRenovateAttributeValue bool, ciGithubPrTargetBranchIsMainAttributeValue bool) {
+func (m *metricRenovatePrsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryNameAttributeValue string, ciGithubPrStateAttributeValue string, ciGithubPrTargetBranchIsMainAttributeValue bool, ciGithubPrNumberAttributeValue int64) {
 	if !m.config.Enabled {
 		return
 	}
@@ -316,10 +316,9 @@ func (m *metricRenovatePrsCount) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp.SetTimestamp(ts)
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
-	dp.Attributes().PutStr("ci.github.pr.author", ciGithubPrAuthorAttributeValue)
 	dp.Attributes().PutStr("ci.github.pr.state", ciGithubPrStateAttributeValue)
-	dp.Attributes().PutBool("ci.github.pr.is_renovate", ciGithubPrIsRenovateAttributeValue)
 	dp.Attributes().PutBool("ci.github.pr.target_branch.is_main", ciGithubPrTargetBranchIsMainAttributeValue)
+	dp.Attributes().PutInt("ci.github.pr.number", ciGithubPrNumberAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -598,8 +597,8 @@ func (mb *MetricsBuilder) RecordBuildInfoDataPoint(ts pcommon.Timestamp, val int
 }
 
 // RecordRenovatePrsCountDataPoint adds a data point to renovate.prs.count metric.
-func (mb *MetricsBuilder) RecordRenovatePrsCountDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryNameAttributeValue string, ciGithubPrAuthorAttributeValue string, ciGithubPrStateAttributeValue AttributeCiGithubPrState, ciGithubPrIsRenovateAttributeValue bool, ciGithubPrTargetBranchIsMainAttributeValue bool) {
-	mb.metricRenovatePrsCount.recordDataPoint(mb.startTime, ts, val, vcsRepositoryNameAttributeValue, ciGithubPrAuthorAttributeValue, ciGithubPrStateAttributeValue.String(), ciGithubPrIsRenovateAttributeValue, ciGithubPrTargetBranchIsMainAttributeValue)
+func (mb *MetricsBuilder) RecordRenovatePrsCountDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryNameAttributeValue string, ciGithubPrStateAttributeValue AttributeCiGithubPrState, ciGithubPrTargetBranchIsMainAttributeValue bool, ciGithubPrNumberAttributeValue int64) {
+	mb.metricRenovatePrsCount.recordDataPoint(mb.startTime, ts, val, vcsRepositoryNameAttributeValue, ciGithubPrStateAttributeValue.String(), ciGithubPrTargetBranchIsMainAttributeValue, ciGithubPrNumberAttributeValue)
 }
 
 // RecordWorkflowJobsCountDataPoint adds a data point to workflow.jobs.count metric.

--- a/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_metrics.go
@@ -307,7 +307,7 @@ func (m *metricRenovatePrsCount) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricRenovatePrsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryNameAttributeValue string, ciGithubPrStateAttributeValue string, ciGithubPrTargetBranchIsMainAttributeValue bool, ciGithubPrNumberAttributeValue int64) {
+func (m *metricRenovatePrsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryNameAttributeValue string, ciGithubPrStateAttributeValue string, ciGithubPrTargetBranchIsMainAttributeValue bool) {
 	if !m.config.Enabled {
 		return
 	}
@@ -318,7 +318,6 @@ func (m *metricRenovatePrsCount) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
 	dp.Attributes().PutStr("ci.github.pr.state", ciGithubPrStateAttributeValue)
 	dp.Attributes().PutBool("ci.github.pr.target_branch.is_main", ciGithubPrTargetBranchIsMainAttributeValue)
-	dp.Attributes().PutInt("ci.github.pr.number", ciGithubPrNumberAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -597,8 +596,8 @@ func (mb *MetricsBuilder) RecordBuildInfoDataPoint(ts pcommon.Timestamp, val int
 }
 
 // RecordRenovatePrsCountDataPoint adds a data point to renovate.prs.count metric.
-func (mb *MetricsBuilder) RecordRenovatePrsCountDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryNameAttributeValue string, ciGithubPrStateAttributeValue AttributeCiGithubPrState, ciGithubPrTargetBranchIsMainAttributeValue bool, ciGithubPrNumberAttributeValue int64) {
-	mb.metricRenovatePrsCount.recordDataPoint(mb.startTime, ts, val, vcsRepositoryNameAttributeValue, ciGithubPrStateAttributeValue.String(), ciGithubPrTargetBranchIsMainAttributeValue, ciGithubPrNumberAttributeValue)
+func (mb *MetricsBuilder) RecordRenovatePrsCountDataPoint(ts pcommon.Timestamp, val int64, vcsRepositoryNameAttributeValue string, ciGithubPrStateAttributeValue AttributeCiGithubPrState, ciGithubPrTargetBranchIsMainAttributeValue bool) {
+	mb.metricRenovatePrsCount.recordDataPoint(mb.startTime, ts, val, vcsRepositoryNameAttributeValue, ciGithubPrStateAttributeValue.String(), ciGithubPrTargetBranchIsMainAttributeValue)
 }
 
 // RecordWorkflowJobsCountDataPoint adds a data point to workflow.jobs.count metric.

--- a/receiver/githubactionsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_metrics_test.go
@@ -65,7 +65,7 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordRenovatePrsCountDataPoint(ts, 1, "vcs.repository.name-val", AttributeCiGithubPrStateOpen, true, 19)
+			mb.RecordRenovatePrsCountDataPoint(ts, 1, "vcs.repository.name-val", AttributeCiGithubPrStateOpen, true)
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -135,9 +135,6 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("ci.github.pr.target_branch.is_main")
 					assert.True(t, ok)
 					assert.True(t, attrVal.Bool())
-					attrVal, ok = dp.Attributes().Get("ci.github.pr.number")
-					assert.True(t, ok)
-					assert.EqualValues(t, 19, attrVal.Int())
 				case "workflow.jobs.count":
 					assert.False(t, validatedMetrics["workflow.jobs.count"], "Found a duplicate in the metrics slice: workflow.jobs.count")
 					validatedMetrics["workflow.jobs.count"] = true

--- a/receiver/githubactionsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/githubactionsreceiver/internal/metadata/generated_metrics_test.go
@@ -65,7 +65,7 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordRenovatePrsCountDataPoint(ts, 1, "vcs.repository.name-val", "ci.github.pr.author-val", AttributeCiGithubPrStateOpen, true, true)
+			mb.RecordRenovatePrsCountDataPoint(ts, 1, "vcs.repository.name-val", AttributeCiGithubPrStateOpen, true, 19)
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -129,18 +129,15 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok := dp.Attributes().Get("vcs.repository.name")
 					assert.True(t, ok)
 					assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("ci.github.pr.author")
-					assert.True(t, ok)
-					assert.Equal(t, "ci.github.pr.author-val", attrVal.Str())
 					attrVal, ok = dp.Attributes().Get("ci.github.pr.state")
 					assert.True(t, ok)
 					assert.Equal(t, "open", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("ci.github.pr.is_renovate")
-					assert.True(t, ok)
-					assert.True(t, attrVal.Bool())
 					attrVal, ok = dp.Attributes().Get("ci.github.pr.target_branch.is_main")
 					assert.True(t, ok)
 					assert.True(t, attrVal.Bool())
+					attrVal, ok = dp.Attributes().Get("ci.github.pr.number")
+					assert.True(t, ok)
+					assert.EqualValues(t, 19, attrVal.Int())
 				case "workflow.jobs.count":
 					assert.False(t, validatedMetrics["workflow.jobs.count"], "Found a duplicate in the metrics slice: workflow.jobs.count")
 					validatedMetrics["workflow.jobs.count"] = true

--- a/receiver/githubactionsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/githubactionsreceiver/internal/metadata/testdata/config.yaml
@@ -3,6 +3,8 @@ all_set:
   metrics:
     build.info:
       enabled: true
+    renovate.prs.count:
+      enabled: true
     workflow.jobs.count:
       enabled: true
     workflow.runs.count:
@@ -10,6 +12,8 @@ all_set:
 none_set:
   metrics:
     build.info:
+      enabled: false
+    renovate.prs.count:
       enabled: false
     workflow.jobs.count:
       enabled: false

--- a/receiver/githubactionsreceiver/metadata.yaml
+++ b/receiver/githubactionsreceiver/metadata.yaml
@@ -84,9 +84,6 @@ attributes:
   ci.github.pr.target_branch.is_main:
     description: Whether the PR target branch is the main branch
     type: bool
-  ci.github.pr.number:
-    description: Pull request number
-    type: int
 
 metrics:
   workflow.jobs.count:
@@ -141,5 +138,4 @@ metrics:
         vcs.repository.name,
         ci.github.pr.state,
         ci.github.pr.target_branch.is_main,
-        ci.github.pr.number,
       ]

--- a/receiver/githubactionsreceiver/metadata.yaml
+++ b/receiver/githubactionsreceiver/metadata.yaml
@@ -75,6 +75,21 @@ attributes:
   version:
     description: The version of the cicd_o11y collector.
     type: string
+  ci.github.pr.author:
+    description: Pull request author
+    type: string
+  ci.github.pr.state:
+    description: Pull request state
+    enum:
+      - open
+      - closed
+    type: string
+  ci.github.pr.is_renovate:
+    description: Whether the PR is created by Renovate
+    type: bool
+  ci.github.pr.target_branch.is_main:
+    description: Whether the PR target branch is the main branch
+    type: bool
 
 metrics:
   workflow.jobs.count:
@@ -116,3 +131,19 @@ metrics:
     gauge:
       value_type: int
     attributes: [version]
+  renovate.prs.count:
+    enabled: true
+    description: Number of Renovate pull requests.
+    unit: "{pr}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes:
+      [
+        vcs.repository.name,
+        ci.github.pr.author,
+        ci.github.pr.state,
+        ci.github.pr.is_renovate,
+        ci.github.pr.target_branch.is_main,
+      ]

--- a/receiver/githubactionsreceiver/metadata.yaml
+++ b/receiver/githubactionsreceiver/metadata.yaml
@@ -75,21 +75,18 @@ attributes:
   version:
     description: The version of the cicd_o11y collector.
     type: string
-  ci.github.pr.author:
-    description: Pull request author
-    type: string
   ci.github.pr.state:
     description: Pull request state
     enum:
       - open
       - closed
     type: string
-  ci.github.pr.is_renovate:
-    description: Whether the PR is created by Renovate
-    type: bool
   ci.github.pr.target_branch.is_main:
     description: Whether the PR target branch is the main branch
     type: bool
+  ci.github.pr.number:
+    description: Pull request number
+    type: int
 
 metrics:
   workflow.jobs.count:
@@ -142,8 +139,7 @@ metrics:
     attributes:
       [
         vcs.repository.name,
-        ci.github.pr.author,
         ci.github.pr.state,
-        ci.github.pr.is_renovate,
         ci.github.pr.target_branch.is_main,
+        ci.github.pr.number,
       ]

--- a/receiver/githubactionsreceiver/metric_event_handling.go
+++ b/receiver/githubactionsreceiver/metric_event_handling.go
@@ -193,7 +193,7 @@ func (m *metricsHandler) workflowRunEventToMetrics(event *github.WorkflowRunEven
 
 			m.mb.RecordRenovatePrsCountDataPoint(now, 1, repo, prState, isMain, int64(prNumber))
 
-			m.logger.Debug("Recorded Renovate PR metric",
+			m.logger.Info("Recorded Renovate PR metric",
 				zap.String("repo", repo),
 				zap.String("state", prState.String()),
 				zap.Bool("is_targeting_main", isMain),

--- a/receiver/githubactionsreceiver/metric_event_handling.go
+++ b/receiver/githubactionsreceiver/metric_event_handling.go
@@ -184,12 +184,12 @@ func (m *metricsHandler) workflowRunEventToMetrics(event *github.WorkflowRunEven
 			} else {
 				prState = metadata.AttributeCiGithubPrStateOpen
 			}
-			
+
 			// Record Renovate PR metric for caching
 			metricKey := fmt.Sprintf("renovate_pr:%s:%s:%s:%t:%t", repo, prAuthor, prState.String(), isRenovate, isMain)
 			if _, alreadyRecorded := m.recordedInThisEmission.LoadOrStore(metricKey, true); !alreadyRecorded {
 				m.mb.RecordRenovatePrsCountDataPoint(now, 1, repo, prAuthor, prState, isRenovate, isMain)
-				
+
 				m.logger.Debug("Recorded Renovate PR metric",
 					zap.String("repo", repo),
 					zap.String("author", prAuthor),
@@ -273,7 +273,7 @@ func (m *metricsHandler) detectRenovatePR(event *github.WorkflowRunEvent) (bool,
 	}
 
 	workflowRun := event.GetWorkflowRun()
-	
+
 	// Check if this is from a PR
 	if len(workflowRun.PullRequests) == 0 {
 		return false, ""
@@ -281,12 +281,12 @@ func (m *metricsHandler) detectRenovatePR(event *github.WorkflowRunEvent) (bool,
 
 	// Check PR title and head branch for Renovate patterns
 	actor := workflowRun.GetActor()
-	
+
 	var prAuthor string
 	if actor != nil {
 		prAuthor = actor.GetLogin()
 	}
-	
+
 	// Check for Renovate/Dependabot patterns in branch name, actor, or PR titles
 	isRenovate := strings.Contains(strings.ToLower(prAuthor), "renovate-sh-app[bot]")
 

--- a/receiver/githubactionsreceiver/metric_event_handling.go
+++ b/receiver/githubactionsreceiver/metric_event_handling.go
@@ -294,11 +294,11 @@ func (m *metricsHandler) detectRenovatePR(event *github.WorkflowRunEvent) bool {
 	if actor != nil {
 		prAuthor = actor.GetLogin()
 	}
-	
+
 	// Get additional actor fields for debugging
 	sender := event.GetSender()
 	triggeringActor := workflowRun.GetTriggeringActor()
-	
+
 	var senderLogin, triggeringActorLogin string
 	if sender != nil {
 		senderLogin = sender.GetLogin()
@@ -317,8 +317,8 @@ func (m *metricsHandler) detectRenovatePR(event *github.WorkflowRunEvent) bool {
 	)
 
 	// Check for Renovate patterns in actor name
-	isRenovate := strings.Contains(prAuthor, "renovate-sh-app[bot]") || 
-		strings.Contains(senderLogin, "renovate-sh-app[bot]") || 
+	isRenovate := strings.Contains(prAuthor, "renovate-sh-app[bot]") ||
+		strings.Contains(senderLogin, "renovate-sh-app[bot]") ||
 		strings.Contains(triggeringActorLogin, "renovate-sh-app[bot]")
 
 	m.logger.Info("Checking if PR is from Renovate",

--- a/receiver/githubactionsreceiver/metric_event_handling.go
+++ b/receiver/githubactionsreceiver/metric_event_handling.go
@@ -284,7 +284,7 @@ func (m *metricsHandler) detectRenovatePR(event *github.WorkflowRunEvent) bool {
 		zap.Int("pr_count", len(workflowRun.PullRequests)),
 		zap.String("event", event.GetWorkflowRun().GetEvent()),
 	)
-	
+
 	if len(workflowRun.PullRequests) == 0 {
 		return false
 	}

--- a/receiver/githubactionsreceiver/metric_event_handling.go
+++ b/receiver/githubactionsreceiver/metric_event_handling.go
@@ -298,6 +298,7 @@ func (m *metricsHandler) detectRenovatePR(event *github.WorkflowRunEvent) bool {
 	// Get additional actor fields for debugging
 	sender := event.GetSender()
 	triggeringActor := workflowRun.GetTriggeringActor()
+	headCommitAuthorName := workflowRun.GetHeadCommit().GetAuthor().GetName()
 
 	var senderLogin, triggeringActorLogin string
 	if sender != nil {
@@ -314,6 +315,7 @@ func (m *metricsHandler) detectRenovatePR(event *github.WorkflowRunEvent) bool {
 		zap.String("triggering_actor_login", triggeringActorLogin),
 		zap.String("head_branch", workflowRun.GetHeadBranch()),
 		zap.String("workflow_event", workflowRun.GetEvent()),
+		zap.String("head_commit_author_name", headCommitAuthorName),
 	)
 
 	// Check for Renovate patterns in actor name

--- a/receiver/githubactionsreceiver/receiver.go
+++ b/receiver/githubactionsreceiver/receiver.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -239,7 +240,7 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 			return
 		}
 	case *github.WorkflowRunEvent:
-		if gar.metricsConsumer != nil && e.GetWorkflowRun().GetEvent() == "push" {
+		if gar.metricsConsumer != nil && (e.GetWorkflowRun().GetEvent() == "push" || (e.GetWorkflowRun().GetEvent() == "pull_request" && gar.metricsHandler.detectRenovatePR(e))) {
 			err := gar.metricsConsumer.ConsumeMetrics(ctx, gar.metricsHandler.workflowRunEventToMetrics(e))
 
 			if err != nil {
@@ -305,3 +306,4 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 
 	w.WriteHeader(http.StatusAccepted)
 }
+

--- a/receiver/githubactionsreceiver/receiver.go
+++ b/receiver/githubactionsreceiver/receiver.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -306,4 +305,3 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 
 	w.WriteHeader(http.StatusAccepted)
 }
-


### PR DESCRIPTION
Adds `renovate.prs.count` metric to monitor open/closed `renovate` PRs.

