### PR TITLE
Trim BOM prefix from log timestamps & restore RFC3339 use

### DIFF
--- a/receiver/githubactionsreceiver/log_event_handling.go
+++ b/receiver/githubactionsreceiver/log_event_handling.go
@@ -306,7 +306,7 @@ func parseTimestamp(line string, logger *zap.Logger) (time.Time, string, bool) {
 		return time.Time{}, "", false
 	}
 
-	parsedTime, err = time.Parse(time.RFC3339Nano, ts)
+	parsedTime, err = time.Parse(time.RFC3339, strings.TrimSpace(strings.TrimPrefix(ts, "\uFEFF")))
 	if err != nil {
 		logger.Debug("Failed to parse timestamp", zap.String("timestamp", ts), zap.Error(err))
 		return time.Time{}, "", false


### PR DESCRIPTION
As part of https://github.com/grafana/grafana-ci-otel-collector/issues/278 we have identified that the first lines of GHA logs contain a BOM (byte-order-mark) prefix.

When this prefix is present initial log lines are orphaned:
```
{"level":"debug","ts":"2025-07-22T16:52:20.570Z","logger":"eventToLogs","caller":"githubactionsreceiver@v0.1.0/log_event_handling.go:313","msg":"Failed to parse timestamp"..."timestamp":"2025-07-22T16:50:49.0811431Z","error":"parsing time \"\\xef\\xbb\\xbf2025-07-22T16:50:49.0811431Z\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\\xef\\xbb\\xbf2025-07-22T16:50:49.0811431Z\" as \"2006\""}

{"level":"error","ts":"2025-07-22T16:52:20.570Z","logger":"eventToLogs","caller":"githubactionsreceiver@v0.1.0/log_event_handling.go:266","msg":"Orphaned log line without preceding timestamp"..."line":"2025-07-22T16:50:49.0811431Z ##[group]Run make lint-jsonnet"
```

This was initially thought to be due to the timestamp formatting however on testing we see that removal of the BOM prefix is all that is needed to prepare timestamps for correct parsing

This PR therefore restores format on parse target back to RFC3339 and trims any present BOM prefixes