### PR TITLE
Modify trace event workflow run&job events log level to debug

### DIFF
--- a/receiver/githubactionsreceiver/trace_event_handling.go
+++ b/receiver/githubactionsreceiver/trace_event_handling.go
@@ -24,7 +24,7 @@ func eventToTraces(event interface{}, config *Config, logger *zap.Logger) (*ptra
 
 	switch e := event.(type) {
 	case *github.WorkflowJobEvent:
-		logger.Info("Processing WorkflowJobEvent", zap.Int64("job_id", e.WorkflowJob.GetID()), zap.String("job_name", e.GetWorkflowJob().GetName()), zap.String("repo", e.GetRepo().GetFullName()))
+		logger.Debug("Processing WorkflowJobEvent", zap.Int64("job_id", e.WorkflowJob.GetID()), zap.String("job_name", e.GetWorkflowJob().GetName()), zap.String("repo", e.GetRepo().GetFullName()))
 		jobResource := resourceSpans.Resource()
 		createResourceAttributes(jobResource, e, config, logger)
 
@@ -40,7 +40,7 @@ func eventToTraces(event interface{}, config *Config, logger *zap.Logger) (*ptra
 		processSteps(scopeSpans, e.GetWorkflowJob().Steps, e.GetWorkflowJob(), defaultBranch, traceID, parentSpanID, logger)
 
 	case *github.WorkflowRunEvent:
-		logger.Info("Processing WorkflowRunEvent", zap.Int64("workflow_id", e.GetWorkflowRun().GetID()), zap.String("workflow_name", e.GetWorkflowRun().GetName()), zap.String("repo", e.GetRepo().GetFullName()))
+		logger.Debug("Processing WorkflowRunEvent", zap.Int64("workflow_id", e.GetWorkflowRun().GetID()), zap.String("workflow_name", e.GetWorkflowRun().GetName()), zap.String("repo", e.GetRepo().GetFullName()))
 		runResource := resourceSpans.Resource()
 
 		traceID, err := generateTraceID(e.GetWorkflowRun().GetID(), e.GetWorkflowRun().GetRunAttempt())


### PR DESCRIPTION
This PR aims to further reduce logging at info level to optimise memory usage in ops

WF job and run events for traces are running at info level, so this change modifies to debug in line with our log event handling [source](https://github.com/grafana/grafana-ci-otel-collector/blob/7c75d22158223689501c5f89744491a1f1f3b7ca/receiver/githubactionsreceiver/log_event_handling.go#L50C24-L50C40)