### PR TITLE
chore: upgrade Go to 1.24.5

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -51,7 +51,7 @@ lint:
 .PHONY: tidy
 tidy:
 	-rm go.sum
-	go mod tidy -compat=1.23
+	go mod tidy -compat=1.24
 
 .PHONY: gen
 gen:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-ci-otel-collector
 
-go 1.23.1
+go 1.24.5
 
 replace github.com/grafana/grafana-ci-otel-collector/receiver/dronereceiver => ./receiver/dronereceiver
 

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -1,6 +1,6 @@
 ---
 run:
-  go: "1.23"
+  go: "1.24.5"
   timeout: 10m
   allow-parallel-runners: true
 

--- a/internal/semconv/go.mod
+++ b/internal/semconv/go.mod
@@ -1,3 +1,3 @@
 module github.com/grafana/grafana-ci-otel-collector/internal/semconv
 
-go 1.23.1
+go 1.24.5

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-ci-otel-collector/internal/sharedcomponent
 
-go 1.23.1
+go 1.24.5
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-ci-otel-collector/internal/tools
 
-go 1.23.1
+go 1.24.5
 
 require (
 	github.com/golangci/golangci-lint v1.64.8

--- a/internal/traceutils/go.mod
+++ b/internal/traceutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-ci-otel-collector/internal/traceutils
 
-go 1.23.1
+go 1.24.5
 
 require (
 	github.com/google/uuid v1.6.0

--- a/receiver/dronereceiver/go.mod
+++ b/receiver/dronereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-ci-otel-collector/receiver/dronereceiver
 
-go 1.23.1
+go 1.24.5
 
 require (
 	github.com/99designs/httpsignatures-go v0.0.0-20170731043157-88528bf4ca7e

--- a/receiver/githubactionsreceiver/go.mod
+++ b/receiver/githubactionsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-ci-otel-collector/receiver/githubactionsreceiver
 
-go 1.23.1
+go 1.24.5
 
 replace github.com/grafana/grafana-ci-otel-collector/internal/sharedcomponent => ../../internal/sharedcomponent
 


### PR DESCRIPTION
Update all go.mod files, Makefile.Common, and golangci.yaml to use Go 1.24.5. This enables the new `testing.B.Loop()` which we'll be using in a followup.
