### PR TITLE
ci: disable updates of internal references

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,15 @@
+{
+  "packageRules": [
+    // These are internal repositories that do not need to be updated since
+    // already have replace statements in place. 
+    "matchPackageNames": [
+      "github.com/grafana/grafana-ci-otel-collector/receiver/dronereceiver",
+      "github.com/grafana/grafana-ci-otel-collector/receiver/githubactionsreceiver",
+      "github.com/grafana/grafana-ci-otel-collector/internal/sharedcomponent",
+      "github.com/grafana/grafana-ci-otel-collector/internal/semconv",
+      "github.com/grafana/grafana-ci-otel-collector/internal/tools",
+      "github.com/grafana/grafana-ci-otel-collector/internal/traceutils"
+    ],
+    "enabled": false
+  ]
+}


### PR DESCRIPTION
These are not necessary since we have replace statements in place.

Related to https://github.com/grafana/grafana-ci-otel-collector/pull/349