### PR TITLE
chore: group otel updates within renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,13 @@
         "github.com/grafana/grafana-ci-otel-collector/internal/traceutils"
       ],
       "enabled": false
+    },
+    {
+      "groupName": "otel",
+      "groupSlug": "otel",
+      "matchPackageNames": [
+        "go.opentelemetry.io/*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This should make updates there more consistent, reliable, and less noisy.