### PR TITLE
fix(githubactionsreceiver): check if runner group contains the `self-hosted` substring

### DIFF
--- a/receiver/githubactionsreceiver/trace_attributes.go
+++ b/receiver/githubactionsreceiver/trace_attributes.go
@@ -52,10 +52,8 @@ func createResourceAttributes(resource pcommon.Resource, event interface{}, conf
 		attrs.PutStr("ci.github.workflow.job.started_at", e.GetWorkflowJob().GetStartedAt().Format(time.RFC3339))
 		attrs.PutStr("ci.github.workflow.job.status", e.GetWorkflowJob().GetStatus())
 
-		// Grafana self-hosted runners have a Group Name of Default (for prod) and Self-hosted (for dev)
-		// TODO: Update this to only look for self-hosted once we've deployed the change to our prod runners
 		rg := strings.ToLower(e.GetWorkflowJob().GetRunnerGroupName())
-		if rg == "default" || rg == "self-hosted" {
+		if strings.Contains(rg, "self-hosted") {
 			attrs.PutStr("ci.github.workflow.job.runner.ec2_instance_id", strings.Split(e.GetWorkflowJob().GetRunnerName(), "_")[1])
 		}
 


### PR DESCRIPTION
Currently our runner group names for our self-hosted runners are:

* `self-hosted-dev`
* `self-hosted-dev-win`
* `self-hosted-dev-prod`
* `self-hosted-dev-prod-win`

In this PR we fix the condition to match the new runner group names.