### PR TITLE
fix(metric_event_handling): Clear emission map instead of recreating

### DIFF
--- a/receiver/githubactionsreceiver/metric_event_handling.go
+++ b/receiver/githubactionsreceiver/metric_event_handling.go
@@ -132,7 +132,7 @@ func (m *metricsHandler) workflowJobEventToMetrics(event *github.WorkflowJobEven
 
 	result := m.mb.Emit()
 	// Clear the recorded tracking for next emission
-	m.recordedInThisEmission = sync.Map{}
+	m.recordedInThisEmission.Clear()
 	return result
 }
 
@@ -200,7 +200,7 @@ func (m *metricsHandler) workflowRunEventToMetrics(event *github.WorkflowRunEven
 
 	result := m.mb.Emit()
 	// Clear the recorded tracking for next emission
-	m.recordedInThisEmission = sync.Map{}
+	m.recordedInThisEmission.Clear()
 	return result
 }
 


### PR DESCRIPTION
This PR attempts to fix a recurring OOM issue we are seeing on metrics collection
[explore](https://ops.grafana-ops.net/d/gKxo0tnVk/right-sizing?orgId=1&var-datasource=000000134&var-cluster=ops-eu-south-0&var-namespace=cicd-o11y&var-container=$__all&from=2025-09-15T06:28:54.353Z&to=2025-09-15T16:06:06.207Z&timezone=utc)
error:
```
fatal error: sync: unlock of unlocked mutex
```
What appears to be happening is a race condition on the lock for an existing sync.Map of recorded entries. We presently recreate this map, however what's suspected here is that some processes are attempting to read from an old/invalid address of the map `recordedInThisEmission`

This PR updates the clear process to use `.Clear()` rather than a new allocation. The intention here is that each process will be able to continue as the address will be the same 