### PR TITLE
fix(log_event_handling): utilize maxEntryBytes to set scanner buffer

### DIFF
--- a/receiver/githubactionsreceiver/log_event_handling.go
+++ b/receiver/githubactionsreceiver/log_event_handling.go
@@ -292,6 +292,9 @@ func extractStepNumberFromFileName(fileName, jobName string) (int, error) {
 func processLogEntries(reader io.Reader, jobLogsScope plog.ScopeLogs, spanID pcommon.SpanID, traceID pcommon.TraceID, stepNumber int, withTraceInfo bool, logger *zap.Logger, builder *logEntryBuilder) {
 	scanner := bufio.NewScanner(reader)
 
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, maxLogEntryBytes)
+
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {


### PR DESCRIPTION
This PR configures the `bufio.Scanner` buffer in `processLogEntries()` to handle log lines up to the existing `maxLogEntryBytes`.

Previously, the scanner used the [default 64KB limit](https://pkg.go.dev/bufio#pkg-constants), causing ["token too long" errors](https://ops.grafana-ops.net/goto/ff39y80rsd4hsc?orgId=1).