### PR TITLE
chore: upgrade Go to 1.25

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -51,7 +51,7 @@ lint:
 .PHONY: tidy
 tidy:
 	-rm go.sum
-	go mod tidy -compat=1.24
+	go mod tidy -compat=1.25
 
 .PHONY: gen
 gen:

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -1,6 +1,6 @@
 ---
 run:
-  go: "1.24.5"
+  go: "1.25.0"
   timeout: 10m
   allow-parallel-runners: true
 

--- a/internal/semconv/go.mod
+++ b/internal/semconv/go.mod
@@ -1,3 +1,5 @@
 module github.com/grafana/grafana-ci-otel-collector/internal/semconv
 
-go 1.24.5
+go 1.25.0
+
+toolchain go1.26.3

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/grafana-ci-otel-collector/internal/sharedcomponent
 
 go 1.25.0
 
+toolchain go1.26.3
+
 require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.56.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/grafana-ci-otel-collector/internal/tools
 
 go 1.26.1
 
+toolchain go1.26.3
+
 require (
 	github.com/golangci/golangci-lint/v2 v2.11.4
 	github.com/google/osv-scanner/v2 v2.3.5

--- a/internal/traceutils/go.mod
+++ b/internal/traceutils/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/grafana-ci-otel-collector/internal/traceutils
 
 go 1.25.0
 
+toolchain go1.26.3
+
 require (
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-ci-otel-collector/internal/semconv v0.0.0-20250724144144-eaa9d8fde20a

--- a/receiver/dronereceiver/go.mod
+++ b/receiver/dronereceiver/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/grafana-ci-otel-collector/receiver/dronereceiver
 
 go 1.25.0
 
+toolchain go1.26.3
+
 require (
 	github.com/99designs/httpsignatures-go v0.0.0-20170731043157-88528bf4ca7e
 	github.com/drone/drone-go v1.7.1

--- a/receiver/githubactionsreceiver/go.mod
+++ b/receiver/githubactionsreceiver/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/grafana-ci-otel-collector/receiver/githubactionsreceiv
 
 go 1.25.0
 
+toolchain go1.26.3
+
 replace github.com/grafana/grafana-ci-otel-collector/internal/sharedcomponent => ../../internal/sharedcomponent
 
 require (


### PR DESCRIPTION
In this PR:
- We bump go mod directive of the submodules to 1.25
- add `toolchain`. This is picked up from renovate for upgrades

I ran the `osv-scanner` locally and it reports 0 vulnerabilities after this bump


Part of the effort to catch up with the CVEs ([explore](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/projects/1535/version/19926))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the Go version/compat settings across multiple modules and linters, which can affect CI/build reproducibility and dependency resolution.
> 
> **Overview**
> Upgrades the project’s Go baseline to **1.25** by updating `go mod tidy -compat` in `Makefile.Common` and the Go version used by `golangci-lint`.
> 
> Bumps submodule `go.mod` directives to `go 1.25.0` and adds a `toolchain go1.26.3` directive across internal modules and receivers to standardize the build toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aba6eb4900d1474d0cd42bf820f6c69368e9f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->