### PR TITLE
fix: group Go version bumps into a single Renovate PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,6 +32,17 @@
       "matchPackageNames": [
         "go.opentelemetry.io/**"
       ]
+    },
+    {
+      "groupName": "go-version",
+      "groupSlug": "go-version",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "go",
+        "golang"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds a Renovate `packageRule` to group all Go version and toolchain directive bumps across sub-modules into a single PR instead of one per `go.mod`.

Currently, when a new Go patch is released (e.g., 1.26.3 → 1.26.4), Renovate creates 7 separate PRs — one per sub-module. This adds review noise and merge queue churn for what is effectively the same change repeated.

The new rule groups `go` (the `go` directive) and `golang` (the `toolchain` directive) updates under `go-version`, following the same pattern already used for OTel packages.

## Test
After merge, Renovate should collapse the 6 open Go toolchain PRs (#641, #642, #643, #644, #646, #647, #648) into a single grouped PR on its next run.