### PR TITLE
fix: group Go version bumps into a single Renovate PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -50,7 +50,8 @@
           "gomod"
         ],
         "matchDepNames": [
-          "go"
+          "go",
+          "golang"
         ],
         "groupName": "security go-version"
       }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,17 +43,20 @@
         "go",
         "golang"
       ]
-    },
-    {
-      "matchVulnerabilityFix": true,
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepNames": [
-        "go",
-        "golang"
-      ],
-      "groupName": "security go-version"
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "packageRules": [
+      {
+        "matchManagers": [
+          "gomod"
+        ],
+        "matchDepNames": [
+          "go",
+          "golang"
+        ],
+        "groupName": "security go-version"
+      }
+    ]
+  }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,6 +32,17 @@
       "matchPackageNames": [
         "go.opentelemetry.io/**"
       ]
+    },
+    {
+      "groupName": "go-version",
+      "groupSlug": "go-version",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "go",
+        "golang"
+      ]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,17 +46,7 @@
     }
   ],
   "vulnerabilityAlerts": {
-    "packageRules": [
-      {
-        "matchManagers": [
-          "gomod"
-        ],
-        "matchDepNames": [
-          "go",
-          "golang"
-        ],
-        "groupName": "security go-version"
-      }
-    ]
+    "groupName": "security {{{depName}}}",
+    "semanticCommitScope": "security/{{vulnerabilitySeverity}}"
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,18 +35,25 @@
     },
     {
       "groupName": "go-version",
-      "groupSlug": "go-version",
       "matchManagers": [
         "gomod"
       ],
       "matchDepNames": [
-        "go",
-        "golang"
+        "go"
       ]
     }
   ],
   "vulnerabilityAlerts": {
-    "groupName": "security {{{depName}}}",
-    "semanticCommitScope": "security/{{vulnerabilitySeverity}}"
+    "packageRules": [
+      {
+        "matchManagers": [
+          "gomod"
+        ],
+        "matchDepNames": [
+          "go"
+        ],
+        "groupName": "security go-version"
+      }
+    ]
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,6 +43,17 @@
         "go",
         "golang"
       ]
+    },
+    {
+      "matchVulnerabilityFix": true,
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "go",
+        "golang"
+      ],
+      "groupName": "security go-version"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds a Renovate `packageRule` to group all Go version and toolchain directive bumps across sub-modules into a single PR instead of one per `go.mod`.

Currently, when a new Go patch is released (e.g., 1.26.3 → 1.26.4), Renovate creates 7 separate PRs — one per sub-module. This adds review noise and merge queue churn for what is effectively the same change repeated.

The new rule groups `go` (the `go` directive) and `golang` (the `toolchain` directive) updates under `go-version`, following the same pattern already used for OTel packages.

IT should do
```
Regular Go bump:
  - PR #641: chore(deps): update go module directive to v1.26.4
  - Caught by: packageRules → groupName: "go-version"
  - Result: All sub-module regular Go bumps land in this one PR

  Security Go toolchain bumps:
  - PR #642: fix(security/unknown/): update go toolchain directive to v1.26.4 [security]
  - PR #643: fix(security/unknown/internal/semconv): update go toolchain directive to v1.26.4 [security]
  - PR #644: fix(security/unknown/internal/sharedcomponent): update go toolchain directive to v1.26.4 [security]
  - PR #646: fix(security/unknown/internal/traceutils): update go toolchain directive to v1.26.4 [security]
  - PR #647: fix(security/unknown/receiver/dronereceiver): update go toolchain directive to v1.26.4 [security]
  - PR #648: fix(security/unknown/receiver/githubactionsreceiver): update go toolchain directive to v1.26.4 [security]
  - Caught by: vulnerabilityAlerts.packageRules → groupName: "security go-version"
  - Result: All 6 collapse into one PR
  ```

## Test
After merge, Renovate should collapse the 6 open Go toolchain PRs (#641, #642, #643, #644, #646, #647, #648) into a single grouped PR on its next run.