### PR TITLE
chore(renovate): remove overriden vulnerability block

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,49 +12,23 @@
       "enabled": false
     },
     {
-      "matchManagers": [
-        "docker-compose"
-      ],
+      "matchManagers": ["docker-compose"],
       "pinDigests": false
     },
     {
-      "matchManagers": [
-        "docker-compose"
-      ],
-      "matchUpdateTypes": [
-        "pinDigest"
-      ],
+      "matchManagers": ["docker-compose"],
+      "matchUpdateTypes": ["pinDigest"],
       "enabled": false
     },
     {
       "groupName": "otel",
       "groupSlug": "otel",
-      "matchPackageNames": [
-        "go.opentelemetry.io/**"
-      ]
+      "matchPackageNames": ["go.opentelemetry.io/**"]
     },
     {
       "groupName": "go-version",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepNames": [
-        "go"
-      ]
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["golang", "go"]
     }
-  ],
-  "vulnerabilityAlerts": {
-    "packageRules": [
-      {
-        "matchManagers": [
-          "gomod"
-        ],
-        "matchDepNames": [
-          "go",
-          "golang"
-        ],
-        "groupName": "security go-version"
-      }
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
Remove the `vulnerabilityAlerts`, since the defeault cannot be overriden  

https://github.com/grafana/deployment_tools/pull/605434