### PR TITLE
fix(tools): remove runtime-spec pin now that osv-scalibr uses containerd/v2

### DIFF
--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -421,7 +421,3 @@ require (
 	www.velocidex.com/golang/go-ntfs v0.2.0 // indirect
 	www.velocidex.com/golang/regparser v0.0.0-20250203141505-31e704a67ef7 // indirect
 )
-
-// containerd v1.7.x is incompatible with runtime-spec v1.3.0 (*int64 breaking change).
-// Pin to v1.2.1 until osv-scalibr migrates to containerd/containerd/v2.
-replace github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.3.0


### PR DESCRIPTION
## Summary

Removes the `replace` directive that pinned `runtime-spec` to v1.2.1 in `internal/tools/go.mod`.

The pin was added in #583 as a workaround for a diamond dependency conflict: `osv-scalibr` depended on `containerd` v1.7.x (which expected `runtime-spec v1.1.0`), but `moby/buildkit v0.28.1` pulled in `runtime-spec v1.3.0` — a breaking change (`LinuxPids.Limit` went from `int64` to `*int64`).

The root cause was fixed upstream in [google/osv-scalibr#2015](https://github.com/google/osv-scalibr/pull/2015), which migrated osv-scalibr from `containerd` v1 to `containerd/v2`. The current osv-scalibr pseudo-version in our go.mod (`v0.4.6-0.20260612031204-164402d9140e`) already includes that fix, so the pin is no longer needed.

## Test

- Removed the `replace` directive
- `go mod tidy` completes cleanly
- `GOOS=linux go build ./...` compiles without errors
- `runtime-spec` resolves to v1.3.0 as expected