### PR TITLE
fix: group go version updates into a single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,7 +28,8 @@
     {
       "groupName": "go-version",
       "matchManagers": ["gomod"],
-      "matchDepNames": ["golang", "go"]
+      "matchDepNames": ["golang", "go"],
+      "additionalBranchPrefix": ""
     }
   ]
 }


### PR DESCRIPTION
## Summary
Renovate opens separate PRs for Go version bumps in each sub-module (`internal/tools`, `internal/sharedcomponent`, root) because it adds the module path as a branch prefix by default. This causes CI failures when a sub-module PR lands before the root — CI installs Go from the root `go.mod`, which is still on the old version.

Setting `additionalBranchPrefix: ""` on the `go-version` group removes the per-module branch prefix so all Go version updates land on the same branch and therefore the same PR.

## Test
Next Renovate Go version bump should produce a single PR instead of one per module.