### PR TITLE
bug: prevent panic on empty ResourceMetrics in workflowRunEventToMetrics

### DIFF
--- a/receiver/githubactionsreceiver/metric_event_handling.go
+++ b/receiver/githubactionsreceiver/metric_event_handling.go
@@ -249,7 +249,11 @@ func (m *metricsHandler) workflowRunEventToMetrics(event *github.WorkflowRunEven
 	}
 
 	metrics := m.mb.Emit()
-	ms := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	rm := metrics.ResourceMetrics()
+	if rm.Len() == 0 {
+		rm.AppendEmpty().ScopeMetrics().AppendEmpty()
+	}
+	ms := rm.At(0).ScopeMetrics().At(0).Metrics()
 	m.appendRunDurationMetric(ms, event)
 	m.sweepStaleHistograms()
 	return metrics


### PR DESCRIPTION
When a `workflow_run` event arrives with an action not present in the status map (e.g. an unrecognized action type), no data points are recorded before `mb.Emit()` is called. `Emit()` returns an empty Metrics struct, so the subsequent `ResourceMetrics().At(0)` call panics with an index out of range error.

Fix by checking if `ResourceMetrics()` is empty after `Emit()` and appending a blank `ResourceMetrics`/`ScopeMetrics` container before accessing index 0. `appendRunDurationMetric` already guards against no-op cases internally, so the empty container is safe when there's nothing to append.